### PR TITLE
chore: fix invalid shop npub in footer njump link

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -123,7 +123,7 @@ export function Footer({ selectedCollection, onCollectionClick }: FooterProps) {
         {/* Social Links */}
         <div className="mt-8 pt-8 border-t border-slate-200 dark:border-slate-800 flex flex-wrap justify-center gap-6">
           <a
-            href="https://njump.me/npub1yvhvefvam4sdz7pftrjtzj7uqantzpugmqkk7emf3v95rknxm45qhq7l3u"
+            href="https://njump.me/npub1yy0nyk6nj6tg4sx8nd7q5qcdw6pqd5e2cc0e8u2rmcgjhpvm63hsk67xe5"
             target="_blank"
             rel="noopener noreferrer"
             className="flex items-center gap-2 text-sage-600 dark:text-sage-400 hover:text-robotechy-green-dark transition-colors"


### PR DESCRIPTION
## Summary

The shop's Nostr link in the site footer (Social Links section of `src/components/Footer.tsx`) pointed to an npub that **failed its bech32 checksum** — njump rejected it with "invalid checksum" and it did not decode.

This one-line change replaces only that `href` with the shop's canonical npub — the same `MERCHANT_NPUB` already used in `src/hooks/useProducts.ts` (`npub1yy0nyk6nj6tg4sx8nd7q5qcdw6pqd5e2cc0e8u2rmcgjhpvm63hsk67xe5`), which decodes correctly.

The two other njump links in the footer (the "dad" and "sister" personal npubs) are valid and were left untouched. Low-risk.

## Test plan

- Click the **Nostr** shop link in the footer → opens njump to the shop's profile instead of an invalid-checksum error.
- `npm test` green locally (tsc --noEmit, eslint, prettier --check, vitest run, vite build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)