### PR TITLE
feat: show Isaac's live Nostr profile (avatar + bio) in footer About Me

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -55,11 +55,13 @@ export function Footer({ selectedCollection, onCollectionClick }: FooterProps) {
             <div className="flex items-start gap-4 max-w-md mb-4">
               <Avatar className="h-16 w-16 shrink-0">
                 <AvatarImage src={isaacMetadata?.picture} alt={isaacName} />
-                <AvatarFallback className="text-lg">{isaacName.charAt(0)}</AvatarFallback>
+                <AvatarFallback className="text-lg">
+                  {(isaacName.trim().charAt(0) || 'I').toUpperCase()}
+                </AvatarFallback>
               </Avatar>
               <div>
                 <p className="text-sm font-medium text-slate-900 dark:text-white">{isaacName}</p>
-                <p className="text-sm text-sage-600 dark:text-sage-400 mt-1 whitespace-pre-line">
+                <p className="text-sm text-sage-600 dark:text-sage-400 mt-1 whitespace-pre-line line-clamp-3">
                   {isaacBio}
                 </p>
               </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -12,7 +12,20 @@ interface FooterProps {
 // Isaac's personal Nostr identity. The About Me section pulls his avatar and bio
 // live from this profile (kind 0 metadata) so it always matches his Nostr profile.
 const ISAAC_NPUB = 'npub17dfg3tynlv39m0e9z8a0t558e7plet96xg9g4uu6q84caykq8jtqwdy09f';
-const ISAAC_PUBKEY = nip19.decode(ISAAC_NPUB).data as string;
+
+// Decode the npub to a hex pubkey, guarding against an invalid/non-npub value so
+// the footer degrades gracefully (empty pubkey -> useAuthor no-ops) instead of
+// crashing at module init.
+function decodeNpub(npub: string): string {
+  try {
+    const decoded = nip19.decode(npub);
+    return decoded.type === 'npub' ? decoded.data : '';
+  } catch {
+    return '';
+  }
+}
+
+const ISAAC_PUBKEY = decodeNpub(ISAAC_NPUB);
 
 export function Footer({ selectedCollection, onCollectionClick }: FooterProps) {
   const { data: collections } = useCollections();
@@ -40,7 +53,7 @@ export function Footer({ selectedCollection, onCollectionClick }: FooterProps) {
           <div className="md:col-span-2">
             <h4 className="font-semibold mb-3 text-slate-900 dark:text-white">About Me</h4>
             <div className="flex items-start gap-4 max-w-md mb-4">
-              <Avatar className="h-16 w-16 shrink-0 rounded-full object-cover">
+              <Avatar className="h-16 w-16 shrink-0">
                 <AvatarImage src={isaacMetadata?.picture} alt={isaacName} />
                 <AvatarFallback className="text-lg">{isaacName.charAt(0)}</AvatarFallback>
               </Avatar>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,12 +1,28 @@
+import { nip19 } from 'nostr-tools';
 import { useCollections } from '@/hooks/useProducts';
+import { useAuthor } from '@/hooks/useAuthor';
+import { genUserName } from '@/lib/genUserName';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 
 interface FooterProps {
   selectedCollection?: string | null;
   onCollectionClick?: (collectionId: string | null) => void;
 }
 
+// Isaac's personal Nostr identity. The About Me section pulls his avatar and bio
+// live from this profile (kind 0 metadata) so it always matches his Nostr profile.
+const ISAAC_NPUB = 'npub17dfg3tynlv39m0e9z8a0t558e7plet96xg9g4uu6q84caykq8jtqwdy09f';
+const ISAAC_PUBKEY = nip19.decode(ISAAC_NPUB).data as string;
+
 export function Footer({ selectedCollection, onCollectionClick }: FooterProps) {
   const { data: collections } = useCollections();
+
+  const isaac = useAuthor(ISAAC_PUBKEY);
+  const isaacMetadata = isaac.data?.metadata;
+  const isaacName = isaacMetadata?.display_name || isaacMetadata?.name || genUserName(ISAAC_PUBKEY);
+  const isaacBio =
+    isaacMetadata?.about ||
+    "Hi, I'm Isaac! I run Robotechy, a 3D printing shop building things for the Bitcoin community.";
 
   const handleCollectionClick = (collectionId: string | null) => {
     if (onCollectionClick) {
@@ -23,28 +39,18 @@ export function Footer({ selectedCollection, onCollectionClick }: FooterProps) {
         <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
           <div className="md:col-span-2">
             <h4 className="font-semibold mb-3 text-slate-900 dark:text-white">About Me</h4>
-            <p className="text-sm text-sage-600 dark:text-sage-400 max-w-md mb-4">
-              Hi, I'm Isaac! I'm 17 and I run Robotechy with a little help from my{' '}
-              <a
-                href="https://njump.me/npub1jutptdc2m8kgjmudtws095qk2tcale0eemvp4j2xnjnl4nh6669slrf04x"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-robotechy-green-dark hover:underline"
-              >
-                dad
-              </a>{' '}
-              and my{' '}
-              <a
-                href="https://njump.me/npub1sfpeyr9k5jms37q4900mw9q4vze4xwhdxd4avdxjml8rqgjkre8s4lcq9l"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-robotechy-green-dark hover:underline"
-              >
-                sister
-              </a>
-              . I'm currently studying at college, where I'm pursuing my interest in engineering and
-              CAD design. I love 3D printing and building things for the Bitcoin community!
-            </p>
+            <div className="flex items-start gap-4 max-w-md mb-4">
+              <Avatar className="h-16 w-16 shrink-0 rounded-full object-cover">
+                <AvatarImage src={isaacMetadata?.picture} alt={isaacName} />
+                <AvatarFallback className="text-lg">{isaacName.charAt(0)}</AvatarFallback>
+              </Avatar>
+              <div>
+                <p className="text-sm font-medium text-slate-900 dark:text-white">{isaacName}</p>
+                <p className="text-sm text-sage-600 dark:text-sage-400 mt-1 whitespace-pre-line">
+                  {isaacBio}
+                </p>
+              </div>
+            </div>
           </div>
           <div>
             <h4 className="font-semibold mb-3 text-slate-900 dark:text-white">Shop</h4>


### PR DESCRIPTION
## Summary

The footer **About Me** section no longer uses hardcoded copy. It now fetches Isaac's profile **live** from his npub (`npub17dfg3t…`) via the existing `useAuthor` hook (kind 0 metadata), so it stays in sync with his Nostr profile.

It renders:
- His profile picture as a rounded avatar (shadcn `Avatar` / `AvatarImage`, with an `AvatarFallback` initial)
- His name (`display_name || name || genUserName(pubkey)`)
- His bio (`metadata.about`)

Reuses the existing `useAuthor` hook and `genUserName` helper for consistency with the rest of the app (Comments, DMs, AccountSwitcher). The npub is decoded to a hex pubkey with `nip19.decode` from `nostr-tools`.

Graceful states: while loading / if metadata is missing it shows the name placeholder and a short default bio line; it won't crash if metadata is undefined.

This only touches the **About Me** block — no overlap with the separate footer npub-fix chore PR (which edits the Nostr social-link njump href).

## Test plan

Load the site → footer About Me shows Isaac's real profile photo and bio; with relays blocked it shows the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Screenshot

Footer **About Me** now rendering Isaac's live Nostr profile (avatar, name, and bio fetched from his npub):

![Footer About Me showing Isaac's live Nostr profile](https://npub1jwk3ews6j9n6kaz8cdevekkgvajgy7yts4tjezl4r7ktkrnw7gkqh40ape.blossom.band/6325bba20ab894ac229e1274bc834a587fb6d21e88b8547195b887fa345b5f52.png)


---

## Screenshots

Footer **About Me** showing Isaac's live Nostr profile (avatar + name + bio):

| Desktop | Mobile |
|---|---|
| <img src="https://github.com/RobotechyShop/robotechy-website/raw/docs/pr13-screenshots/docs/screenshots/13/footer-about-me-desktop.png" width="420"> | <img src="https://github.com/RobotechyShop/robotechy-website/raw/docs/pr13-screenshots/docs/screenshots/13/footer-about-me-mobile.png" width="200"> |