### PR TITLE
docs: make OG crawler-limitation comments self-contained

### DIFF
--- a/src/lib/productMeta.ts
+++ b/src/lib/productMeta.ts
@@ -49,8 +49,10 @@ export function truncateDescription(text: string, max: number = MAX_DESCRIPTION_
  * NOTE: Robotechy is a client-rendered SPA, so these tags are injected at
  * runtime and are visible to in-app navigation, native share sheets and any
  * future SSR/pre-render — but NOT to social crawlers, which read the raw HTML
- * shell. Store-level previews are handled statically in index.html. See the PR
- * "Limitations / follow-up" section.
+ * shell and do not execute JS. Crawler-visible previews are therefore limited
+ * to the static store-level tags baked into index.html; making per-product
+ * links unfurl for crawlers would require SSR or a crawler-aware shim that
+ * inlines these tags into the served HTML before the SPA boots.
  *
  * @param product Parsed NIP-99 product.
  * @param url     Fully-qualified page URL (e.g. `window.location.href`).

--- a/src/pages/ProductDetail.tsx
+++ b/src/pages/ProductDetail.tsx
@@ -39,8 +39,9 @@ export function ProductDetail({ identifier }: ProductDetailProps) {
 
   // Open Graph / Twitter Card meta for social sharing. These are injected at
   // runtime (client-rendered SPA), so they drive in-app titles, native share
-  // sheets and any future SSR/pre-render — but social crawlers read the static
-  // index.html shell, which carries store-level previews. See PR limitations.
+  // sheets and any future SSR/pre-render — but social crawlers don't run JS, so
+  // they only ever see the static store-level tags in index.html, not these
+  // per-product tags (see src/lib/productMeta.ts for the full rationale).
   //
   // Build the canonical product URL from the naddr route (kind:pubkey:d-tag),
   // matching how ProductCard links here. `identifier` is the NIP-99 `d` tag, so


### PR DESCRIPTION
Follow-up to #30. That PR was merged at commit `5b1e842`, one commit before its final review-fix (`e1522f2`) landed, so `main` still carries two code comments that point readers at the PR's "Limitations / follow-up" section — a dangling reference now that the PR is merged (flagged by Copilot on #30).

This is a **comment-only** change (no functional code): it makes the crawler/SPA limitation notes in `src/lib/productMeta.ts` and `src/pages/ProductDetail.tsx` self-contained and cross-references the in-repo `src/lib/productMeta.ts` rationale instead of the PR.

## Test plan

- `grep -rni 'See the PR\|Limitations / follow-up' src` → no matches after this change (the dangling references are gone).
- `tsc --noEmit`, `prettier --check`, and `vitest run` (12 productMeta cases) all green locally; no behaviour change since only comments are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
