### PR TITLE
feat: also deliver the order invoice as a kind-14 note for generic NIP-17 clients

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,10 +97,36 @@ jobs:
       - name: Check source file sizes
         run: bash scripts/check-file-size.sh
 
+  order-service-test:
+    # The root Vitest config excludes `order-service/**`, so the backend order
+    # service has its own Node built-in test runner suite that the main "Unit
+    # Tests" job never executes. Run it here so its tests (including the #7
+    # single-invoice regression test) are actually enforced on every PR.
+    name: Order Service Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: order-service/package-lock.json
+
+      - name: Install order-service dependencies
+        working-directory: order-service
+        run: npm ci
+
+      - name: Run order-service tests
+        working-directory: order-service
+        run: npm test
+
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [lint, format, typecheck, test, file-size]
+    needs: [lint, format, typecheck, test, file-size, order-service-test]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -44,14 +44,31 @@ sequenceDiagram
     Note over B,M: Each human-facing step also sends a gift-wrapped<br/>kind 14 readable summary → renders in any NIP-17 client<br/>(Damus · Primal · Lightning Piggy)
     Note right of M: unwrap 1059 → seal 13 → rumor 16<br/>verify sender · read order
     M->>L: LNURL-pay request (amount)
-    L-->>M: BOLT11 invoice
-    M->>B: Payment request · gift wrap 1059 ⟶ inner kind 16 type 2<br/>(BOLT11 invoice)
+    L-->>M: BOLT11 invoice (generated ONCE)
+    Note right of M: One invoice, delivered two ways —<br/>same BOLT11, same ["order", id] tag
+    M->>B: Payment request · gift wrap 1059 ⟶ inner kind 16 type 2<br/>(rich "order card" — BOLT11 invoice)
+    M->>B: Invoice note · gift wrap 1059 ⟶ inner kind 14<br/>(SAME BOLT11 — fallback for generic NIP-17 clients)
+    Note over B: Gamma-aware client (Lightning Piggy) shows the<br/>kind 16 card and suppresses the kind 14 duplicate;<br/>a generic client (0xchat · Amethyst) shows the kind 14 note
     B->>L: Pay invoice ⚡
     B->>M: Receipt · gift wrap 1059 ⟶ inner kind 17<br/>(BOLT11 + preimage proof)
     M->>B: Confirmation · gift wrap 1059 ⟶ inner kind 16 type 3<br/>(status: confirmed)
 ```
 
 The **order-service** subscribes to kind 1059 gift wraps addressed to the merchant, unwraps each to its inner rumor (authenticating the sender), dispatches orders (kind 16 type 1) and receipts (kind 17), and replies with gift wraps. It no longer reads plaintext kind 16/17 events or sends NIP-04 DMs.
+
+### One invoice, two surfaces — how clients ignore the duplicate
+
+The payment request is generated as a **single** Lightning invoice (one `generateInvoice` call) and delivered two ways, both gift-wrapped to the buyer:
+
+- a **kind 16 type 2** payment request — the rich, structured "order card" that Gamma-aware clients (and the website) render; and
+- a **kind 14** chat note carrying the **same BOLT11** — a fallback so generic NIP-17 DM clients (0xchat, Amethyst's DM view) that can't draw a kind 16 card still show the invoice.
+
+Both events carry the **identical `["order", "<orderId>"]` tag**, which is the dedup contract for client authors:
+
+- **If a client renders the rich kind 16 order card** for an order id, it should **suppress** any kind 14 chat note carrying the same `["order", "<orderId>"]` tag. Correlate by order id, and dedupe **at render time over the full message set** — arrival order is not guaranteed (NIP-59 randomizes gift-wrap timestamps), so do not decide at ingest.
+- **If no kind 16 card is present** (the client can't render it, or it was lost), **show the kind 14 note** — it is the only copy of the invoice the buyer has.
+
+This is safe with respect to issue #7 (DM invoice diverging from the website invoice, enabling double payment): it is the **same BOLT11** on both surfaces, so a single Lightning invoice settles **once** — even if a buyer tries to pay from both, the second settle simply fails at the Lightning layer. No second invoice is ever generated, and no NIP-04 DM is used.
 
 ### Event Types
 

--- a/README.md
+++ b/README.md
@@ -61,11 +61,16 @@ The **order-service** subscribes to kind 1059 gift wraps addressed to the mercha
 The payment request is generated as a **single** Lightning invoice (one `generateInvoice` call) and delivered two ways, both gift-wrapped to the buyer:
 
 - a **kind 16 type 2** payment request — the rich, structured "order card" that Gamma-aware clients (and the website) render; and
-- a **kind 14** chat note carrying the **same BOLT11** — a fallback so generic NIP-17 DM clients (0xchat, Amethyst's DM view) that can't draw a kind 16 card still show the invoice.
+- a **kind 14** chat note whose `content` carries a short human-readable line **followed by the raw `lnbc…` BOLT11 string** (verbatim, so LN-aware clients make it tappable) — a fallback so generic NIP-17 DM clients (0xchat, Amethyst's DM view) that can't draw a kind 16 card still show the invoice.
 
-Both events carry the **identical `["order", "<orderId>"]` tag**, which is the dedup contract for client authors:
+**Two correlation keys — use whichever you can access.** The two events are linked by _both_ of the following, and a client only needs one of them to dedupe:
 
-- **If a client renders the rich kind 16 order card** for an order id, it should **suppress** any kind 14 chat note carrying the same `["order", "<orderId>"]` tag. Correlate by order id, and dedupe **at render time over the full message set** — arrival order is not guaranteed (NIP-59 randomizes gift-wrap timestamps), so do not decide at ingest.
+1. **By order id** — both events carry the identical `["order", "<orderId>"]` tag. Clients that retain event tags dedupe on that.
+2. **By invoice** — both carry the identical BOLT11: the kind 16's `["payment","lightning","<bolt11>"]` value and the kind 14's `content` text contain the exact same `lnbc…` string. Clients whose message store does **not** persist tags (e.g. Lightning Piggy) dedupe on the exact invoice string extracted from the note text.
+
+Either key works precisely because it is **one** invoice. The dedup contract for client authors:
+
+- **If a client renders the rich kind 16 order card** for an order, it should **suppress** the matching kind 14 chat note — matched by the shared order id _or_ the shared BOLT11. Dedupe **at render time over the full message set**, not at ingest: arrival order is not guaranteed (NIP-59 randomizes gift-wrap timestamps), so the note may arrive before the card.
 - **If no kind 16 card is present** (the client can't render it, or it was lost), **show the kind 14 note** — it is the only copy of the invoice the buyer has.
 
 This is safe with respect to issue #7 (DM invoice diverging from the website invoice, enabling double payment): it is the **same BOLT11** on both surfaces, so a single Lightning invoice settles **once** — even if a buyer tries to pay from both, the second settle simply fails at the Lightning layer. No second invoice is ever generated, and no NIP-04 DM is used.

--- a/order-service/index.js
+++ b/order-service/index.js
@@ -63,6 +63,21 @@ function formatInvoiceNote(orderId, amountSats) {
 }
 
 /**
+ * Format the human-readable kind-14 chat note that carries the SAME BOLT11 as
+ * the kind-16 payment-request card. Generic NIP-17 DM clients (0xchat, Amethyst's
+ * DM view, etc.) only render kind-14 chat rumors — they can't draw a kind-16
+ * marketplace order card — so without this the buyer never sees the invoice in
+ * those clients. The raw BOLT11 is included on its own line so LN-aware clients
+ * make it tappable. This is NOT a second invoice: it embeds the one invoice
+ * `generateInvoice` returned, so it cannot diverge from the website invoice
+ * (#7) — a single BOLT11 settles once, any second pay attempt simply fails.
+ */
+function formatInvoiceChatNote(orderId, amountSats, invoice) {
+  const orderIdShort = orderId.slice(0, 8);
+  return `⚡ Invoice for order #${orderIdShort} — ${amountSats.toLocaleString()} sats:\n${invoice}`;
+}
+
+/**
  * Format a human-readable thank-you note to ride inside the gift-wrapped status
  * update rumor's `content` field.
  */
@@ -74,12 +89,15 @@ function formatThankYouNote(orderId) {
 /**
  * Handle incoming order (Kind 16 Type 1)
  *
- * Generates exactly ONE Lightning invoice for the order and threads that single
- * invoice into ONE gift-wrapped Kind 16 Type 2 payment request. This is the
- * invariant that fixes #7 (DM invoice diverging from the website invoice): there
- * is no second invoice and no separate NIP-04 DM — see the comment at the
- * gift-wrap call below. The regression test in test/single-invoice.test.js locks
- * this in.
+ * Generates exactly ONE Lightning invoice for the order and delivers that single
+ * BOLT11 two ways, both gift-wrapped to the buyer: a Kind 16 Type 2 payment
+ * request (the marketplace order card) AND a NIP-17 kind-14 chat note (a fallback
+ * for generic DM clients that can't render the kind-16 card). Both carry the
+ * IDENTICAL invoice and the same ['order', id] tag, so they can never diverge —
+ * the invariant that fixes #7 (DM invoice diverging from the website invoice).
+ * One BOLT11 settles once, so the kind-14 copy cannot enable double payment. No
+ * separate NIP-04 DM is used. The regression test in test/single-invoice.test.js
+ * locks this in.
  *
  * `generateInvoice` is injected (defaulting to the real LNURL implementation) so
  * the order flow can be exercised hermetically in tests — no network, and the
@@ -135,6 +153,25 @@ export async function handleOrder(
 
     console.log(`[Order] Sending gift-wrapped payment request to buyer...`);
     await nostrClient.sendGiftWrap(order.buyerPubkey, paymentRequestRumor);
+
+    // ALSO deliver the SAME invoice as a gift-wrapped NIP-17 kind-14 chat note.
+    // Generic NIP-17 clients (0xchat, Amethyst DM view) can't render the kind-16
+    // order card, so they'd never show the invoice; the kind-14 fallback makes the
+    // raw BOLT11 visible (and tappable) there. Crucially it reuses `invoice` — the
+    // one and only invoice generated above — and carries the SAME ['order', id]
+    // tag as the kind-16 event so rich clients can correlate/dedupe the two. This
+    // is safe re #7: one BOLT11 settles once; a second pay attempt simply fails.
+    const invoiceChatRumor = {
+      kind: 14,
+      content: formatInvoiceChatNote(order.orderId, order.amount, invoice),
+      tags: [
+        ['p', order.buyerPubkey],
+        ['order', order.orderId],
+      ],
+    };
+
+    console.log(`[Order] Sending gift-wrapped kind-14 invoice note to buyer...`);
+    await nostrClient.sendGiftWrap(order.buyerPubkey, invoiceChatRumor);
 
     console.log(`[Order] ✓ Order ${order.orderId.slice(0, 8)} processed - payment request sent`);
   } catch (error) {

--- a/order-service/index.js
+++ b/order-service/index.js
@@ -100,19 +100,21 @@ function formatThankYouNote(orderId) {
  * separate NIP-04 DM is used. The regression test in test/single-invoice.test.js
  * locks this in.
  *
- * `generateInvoice` is injected (defaulting to the real LNURL implementation) so
- * the order flow can be exercised hermetically in tests — no network, and the
- * test can assert it is called exactly once with the returned BOLT11 ending up
- * in the payment-request event.
+ * `generateInvoice` and `store` are injected (defaulting to the real LNURL
+ * implementation and the module-level persisted dedup store) so the order flow
+ * can be exercised hermetically in tests — no network and no disk writes — while
+ * production keeps using the on-disk store. The test can then assert
+ * `generateInvoice` is called exactly once with the returned BOLT11 ending up in
+ * the payment-request event.
  *
  * @param {Omit<import('nostr-tools').Event, 'id'|'sig'>} event - inner order rumor
  * @param {NostrClient} nostrClient
- * @param {{ generateInvoice?: typeof generateInvoice }} [deps]
+ * @param {{ generateInvoice?: typeof generateInvoice, store?: ProcessedStore }} [deps]
  */
 export async function handleOrder(
   event,
   nostrClient,
-  { generateInvoice: genInvoice = generateInvoice } = {}
+  { generateInvoice: genInvoice = generateInvoice, store = processedStore } = {}
 ) {
   const order = parseOrderEvent(event);
   if (!order) {
@@ -120,11 +122,11 @@ export async function handleOrder(
   }
 
   // Skip if already processed (persisted across restarts to avoid re-invoicing)
-  if (processedStore.hasOrder(order.orderId)) {
+  if (store.hasOrder(order.orderId)) {
     console.log(`[Order] Skipping duplicate order ${order.orderId.slice(0, 8)}`);
     return;
   }
-  processedStore.addOrder(order.orderId);
+  store.addOrder(order.orderId);
 
   console.log(`[Order] New order received!`);
   console.log(`  Order ID: ${order.orderId.slice(0, 8)}`);

--- a/order-service/index.js
+++ b/order-service/index.js
@@ -23,6 +23,7 @@ process.on('unhandledRejection', (reason) => {
   process.exit(1);
 });
 
+import { pathToFileURL } from 'url';
 import { config } from './lib/config.js';
 import { isIgnorableRelayError } from './lib/relayErrors.js';
 import { NostrClient, decodeNsec } from './lib/nostr.js';
@@ -72,8 +73,28 @@ function formatThankYouNote(orderId) {
 
 /**
  * Handle incoming order (Kind 16 Type 1)
+ *
+ * Generates exactly ONE Lightning invoice for the order and threads that single
+ * invoice into ONE gift-wrapped Kind 16 Type 2 payment request. This is the
+ * invariant that fixes #7 (DM invoice diverging from the website invoice): there
+ * is no second invoice and no separate NIP-04 DM — see the comment at the
+ * gift-wrap call below. The regression test in test/single-invoice.test.js locks
+ * this in.
+ *
+ * `generateInvoice` is injected (defaulting to the real LNURL implementation) so
+ * the order flow can be exercised hermetically in tests — no network, and the
+ * test can assert it is called exactly once with the returned BOLT11 ending up
+ * in the payment-request event.
+ *
+ * @param {Omit<import('nostr-tools').Event, 'id'|'sig'>} event - inner order rumor
+ * @param {NostrClient} nostrClient
+ * @param {{ generateInvoice?: typeof generateInvoice }} [deps]
  */
-async function handleOrder(event, nostrClient) {
+export async function handleOrder(
+  event,
+  nostrClient,
+  { generateInvoice: genInvoice = generateInvoice } = {}
+) {
   const order = parseOrderEvent(event);
   if (!order) {
     return;
@@ -98,7 +119,7 @@ async function handleOrder(event, nostrClient) {
   try {
     // Generate Lightning invoice
     console.log(`[Order] Generating invoice for ${order.amount} sats...`);
-    const invoice = await generateInvoice(config.lightningAddress, order.amount, order.orderId);
+    const invoice = await genInvoice(config.lightningAddress, order.amount, order.orderId);
 
     // Build the Kind 16 Type 2 payment request rumor and gift-wrap it to the buyer.
     // The structured invoice data lives in the rumor tags; we fold a human-readable
@@ -272,8 +293,15 @@ async function main() {
   console.log('[Service] Waiting for orders... (Ctrl+C to stop)\n');
 }
 
-// Run
-main().catch((error) => {
-  console.error('[Fatal]', error);
-  process.exit(1);
-});
+// Run — but only when executed directly (`node index.js`), not when this module
+// is imported (e.g. by the regression test, which imports `handleOrder`). Guard
+// with an entry-point check so importing the module has no network/relay side
+// effects.
+const isEntryPoint = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isEntryPoint) {
+  main().catch((error) => {
+    console.error('[Fatal]', error);
+    process.exit(1);
+  });
+}

--- a/order-service/index.js
+++ b/order-service/index.js
@@ -23,6 +23,7 @@ process.on('unhandledRejection', (reason) => {
   process.exit(1);
 });
 
+import { resolve } from 'path';
 import { pathToFileURL } from 'url';
 import { config } from './lib/config.js';
 import { isIgnorableRelayError } from './lib/relayErrors.js';
@@ -333,8 +334,11 @@ async function main() {
 // Run — but only when executed directly (`node index.js`), not when this module
 // is imported (e.g. by the regression test, which imports `handleOrder`). Guard
 // with an entry-point check so importing the module has no network/relay side
-// effects.
-const isEntryPoint = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+// effects. `resolve()` makes the script path absolute first (Node already gives
+// an absolute argv[1] for the main module, but resolving is a defensive no-op
+// that keeps pathToFileURL correct even if argv[1] were ever relative).
+const isEntryPoint =
+  process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
 
 if (isEntryPoint) {
   main().catch((error) => {

--- a/order-service/test/single-invoice.test.js
+++ b/order-service/test/single-invoice.test.js
@@ -1,0 +1,192 @@
+/**
+ * Regression test for issue #7:
+ *   "DM invoice may be different from website invoice (double payment possible)."
+ *
+ * The OLD architecture sent TWO invoices for a single order — a Kind 16 Type 2
+ * payment request (shown on the website) AND a separate NIP-04 (kind 4) DM
+ * invoice (`formatInvoiceDM`). Those two BOLT11 strings could diverge, letting a
+ * buyer pay both and lose funds (double payment).
+ *
+ * The current `handleOrder` fixes this by generating exactly ONE invoice and
+ * threading that single BOLT11 into ONE gift-wrapped Kind 16 Type 2 payment
+ * request — with no separate NIP-04 DM. This test locks that invariant in so it
+ * cannot silently regress.
+ *
+ * Hermetic: the Lightning provider (`generateInvoice`) is injected as a spy and
+ * the relay/publish layer is a fake `nostrClient`, so no network is touched.
+ *
+ * Runs on Node's built-in test runner (no extra deps): `node --test`.
+ */
+
+import { test, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { randomBytes } from 'node:crypto';
+
+// `lib/config.js` calls `requireEnv(...)` at import time and `index.js` imports
+// it, so these must be set BEFORE importing index.js. The merchant key is never
+// decoded here (main() is guarded and does not run on import), so any non-empty
+// values suffice to satisfy the config loader.
+process.env.MERCHANT_NSEC ||= 'nsec-test-placeholder';
+process.env.LIGHTNING_ADDRESS ||= 'robotechy@example.com';
+
+const { handleOrder } = await import('../index.js');
+
+// A recognisable BOLT11 the injected provider returns. The test asserts THIS
+// exact string is the one embedded in the payment-request event (the invoice the
+// website displays) — i.e. there is only one invoice, end to end.
+const FAKE_BOLT11 = 'lnbc50u1pregress0nlysingleinvoiceeverpay1tothiswebsiteinvoiceandnodmcopy';
+
+/** A 32-byte hex pubkey (buyer identity for the order rumor). */
+function randomPubkey() {
+  return randomBytes(32).toString('hex');
+}
+
+/**
+ * Build a Kind 16 Type 1 order rumor — the unsigned inner event that
+ * `unwrapGiftWrap` hands to `handleOrder`. A fresh `orderId` per call avoids the
+ * persistent dedup store skipping the order as already-processed.
+ */
+function buildOrderRumor({ buyerPubkey = randomPubkey(), amount = 5000 } = {}) {
+  const orderId = randomBytes(16).toString('hex');
+  return {
+    kind: 16,
+    pubkey: buyerPubkey,
+    content: 'Please send my robot parts',
+    tags: [
+      ['type', '1'], // ORDER_MESSAGE_TYPE.ORDER_CREATION
+      ['order', orderId],
+      ['amount', String(amount)],
+      ['item', '30402:somepubkey:robo-arm', '1'],
+      ['address', '123 Maker St'],
+      ['email', 'buyer@example.com'],
+    ],
+    created_at: Math.floor(Date.now() / 1000),
+  };
+}
+
+/**
+ * Build a fake NostrClient that records every gift wrap and DM instead of
+ * touching the network. `sendDM` is present (so a regressed code path that calls
+ * it would be caught) but must NOT be invoked by the order flow.
+ */
+function buildFakeNostrClient() {
+  const giftWraps = [];
+  const dms = [];
+  return {
+    giftWraps,
+    dms,
+    async sendGiftWrap(recipientPubkey, rumor) {
+      giftWraps.push({ recipientPubkey, rumor });
+    },
+    async sendDM(recipientPubkey, content) {
+      dms.push({ recipientPubkey, content });
+    },
+  };
+}
+
+/** A spy wrapping the Lightning provider: counts calls and records arguments. */
+function buildGenerateInvoiceSpy(returnValue = FAKE_BOLT11) {
+  const calls = [];
+  const fn = async (...args) => {
+    calls.push(args);
+    return returnValue;
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+/** Pull the `['payment', 'lightning', <bolt11>]` tag out of an event. */
+function paymentTagOf(rumor) {
+  return rumor.tags.find((t) => t[0] === 'payment');
+}
+
+/** Pull the single-valued tag (e.g. 'type', 'order', 'amount') from an event. */
+function tagValue(rumor, name) {
+  return rumor.tags.find((t) => t[0] === name)?.[1];
+}
+
+let nostrClient;
+let generateInvoiceSpy;
+
+beforeEach(() => {
+  nostrClient = buildFakeNostrClient();
+  generateInvoiceSpy = buildGenerateInvoiceSpy();
+});
+
+test('generateInvoice is called exactly once for a single order', async () => {
+  const order = buildOrderRumor();
+  await handleOrder(order, nostrClient, { generateInvoice: generateInvoiceSpy });
+
+  assert.equal(
+    generateInvoiceSpy.calls.length,
+    1,
+    'exactly one invoice must be generated per order (no second invoice)'
+  );
+  // ...and it is generated for THIS order's amount and id.
+  const [, amountArg, orderIdArg] = generateInvoiceSpy.calls[0];
+  assert.equal(amountArg, 5000, 'invoice generated for the order amount');
+  assert.equal(orderIdArg, tagValue(order, 'order'), 'invoice generated for this order id');
+});
+
+test('the website Kind 16 Type 2 payment request embeds the SAME invoice generateInvoice returned', async () => {
+  const order = buildOrderRumor();
+  await handleOrder(order, nostrClient, { generateInvoice: generateInvoiceSpy });
+
+  assert.equal(nostrClient.giftWraps.length, 1, 'exactly one gift wrap sent');
+  const { rumor } = nostrClient.giftWraps[0];
+
+  assert.equal(rumor.kind, 16, 'payment request is a Kind 16 event');
+  assert.equal(tagValue(rumor, 'type'), '2', 'Kind 16 Type 2 = payment request');
+
+  const paymentTag = paymentTagOf(rumor);
+  assert.ok(paymentTag, 'payment request event has a payment tag');
+  assert.equal(paymentTag[1], 'lightning', 'payment method is lightning');
+  // The crux of #7: the invoice in the event is the EXACT one generateInvoice
+  // returned — the single source of truth, not a divergent second invoice.
+  assert.equal(
+    paymentTag[2],
+    FAKE_BOLT11,
+    'the event invoice is the one and only invoice generateInvoice returned'
+  );
+});
+
+test('NO separate NIP-04 (kind 4) invoice DM is sent during the order flow', async () => {
+  const order = buildOrderRumor();
+  await handleOrder(order, nostrClient, { generateInvoice: generateInvoiceSpy });
+
+  assert.equal(
+    nostrClient.dms.length,
+    0,
+    'the old separate NIP-04 invoice DM (formatInvoiceDM) must not be sent'
+  );
+  // Defensive: even if a DM were sent, it must never carry the invoice.
+  for (const dm of nostrClient.dms) {
+    assert.ok(!String(dm.content).includes(FAKE_BOLT11), 'no DM may contain the BOLT11 invoice');
+  }
+});
+
+test('exactly one gift-wrapped payment request is sent to the buyer', async () => {
+  const buyerPubkey = randomPubkey();
+  const order = buildOrderRumor({ buyerPubkey });
+  await handleOrder(order, nostrClient, { generateInvoice: generateInvoiceSpy });
+
+  assert.equal(nostrClient.giftWraps.length, 1, 'exactly one gift-wrapped message sent');
+  const { recipientPubkey, rumor } = nostrClient.giftWraps[0];
+  assert.equal(recipientPubkey, buyerPubkey, 'the payment request goes to the buyer');
+  assert.equal(tagValue(rumor, 'type'), '2', 'and it is the Type 2 payment request');
+});
+
+test('a duplicate order is skipped — no second invoice for the same order id', async () => {
+  const order = buildOrderRumor();
+  await handleOrder(order, nostrClient, { generateInvoice: generateInvoiceSpy });
+  // Replay the exact same order (same order id) — the persistent dedup store
+  // must short-circuit it, so no further invoice is generated.
+  await handleOrder(order, nostrClient, { generateInvoice: generateInvoiceSpy });
+
+  assert.equal(
+    generateInvoiceSpy.calls.length,
+    1,
+    'a replayed order must not generate a second invoice'
+  );
+  assert.equal(nostrClient.giftWraps.length, 1, 'and must not send a second payment request');
+});

--- a/order-service/test/single-invoice.test.js
+++ b/order-service/test/single-invoice.test.js
@@ -2,15 +2,20 @@
  * Regression test for issue #7:
  *   "DM invoice may be different from website invoice (double payment possible)."
  *
- * The OLD architecture sent TWO invoices for a single order — a Kind 16 Type 2
- * payment request (shown on the website) AND a separate NIP-04 (kind 4) DM
- * invoice (`formatInvoiceDM`). Those two BOLT11 strings could diverge, letting a
- * buyer pay both and lose funds (double payment).
+ * The OLD architecture sent TWO independently-generated invoices for one order —
+ * a Kind 16 Type 2 payment request (shown on the website) AND a separate NIP-04
+ * (kind 4) DM invoice (`formatInvoiceDM`). Those two BOLT11 strings could diverge,
+ * letting a buyer pay both and lose funds (double payment).
  *
  * The current `handleOrder` fixes this by generating exactly ONE invoice and
- * threading that single BOLT11 into ONE gift-wrapped Kind 16 Type 2 payment
- * request — with no separate NIP-04 DM. This test locks that invariant in so it
- * cannot silently regress.
+ * delivering that single BOLT11 two ways, both gift-wrapped to the buyer:
+ *   - a Kind 16 Type 2 payment-request card (rich marketplace clients / website)
+ *   - a NIP-17 kind-14 chat note carrying the SAME BOLT11 (a fallback so generic
+ *     DM clients that can't render the kind-16 card still show the invoice)
+ * Both copies embed the IDENTICAL invoice and the same ['order', id] tag, so they
+ * can never diverge — and one BOLT11 settles only once, so the second copy cannot
+ * enable double payment. No NIP-04 (kind 4) DM is used. This test locks that
+ * invariant in so it cannot silently regress.
  *
  * Hermetic: the Lightning provider (`generateInvoice`) is injected as a spy and
  * the relay/publish layer is a fake `nostrClient`, so no network is touched.
@@ -105,6 +110,11 @@ function tagValue(rumor, name) {
   return rumor.tags.find((t) => t[0] === name)?.[1];
 }
 
+/** The gift-wrapped rumors of a given kind that were sent. */
+function giftWrapsOfKind(client, kind) {
+  return client.giftWraps.filter((g) => g.rumor.kind === kind);
+}
+
 let nostrClient;
 let generateInvoiceSpy;
 
@@ -128,59 +138,84 @@ test('generateInvoice is called exactly once for a single order', async () => {
   assert.equal(orderIdArg, tagValue(order, 'order'), 'invoice generated for this order id');
 });
 
-test('the website Kind 16 Type 2 payment request embeds the SAME invoice generateInvoice returned', async () => {
+test('the kind-16 card and the kind-14 note both carry the IDENTICAL invoice generateInvoice returned', async () => {
   const order = buildOrderRumor();
   await handleOrder(order, nostrClient, { generateInvoice: generateInvoiceSpy });
 
-  assert.equal(nostrClient.giftWraps.length, 1, 'exactly one gift wrap sent');
-  const { rumor } = nostrClient.giftWraps[0];
-
-  assert.equal(rumor.kind, 16, 'payment request is a Kind 16 event');
-  assert.equal(tagValue(rumor, 'type'), '2', 'Kind 16 Type 2 = payment request');
-
-  const paymentTag = paymentTagOf(rumor);
-  assert.ok(paymentTag, 'payment request event has a payment tag');
+  // The kind-16 Type 2 payment-request card.
+  const cards = giftWrapsOfKind(nostrClient, 16);
+  assert.equal(cards.length, 1, 'exactly one kind-16 payment-request card sent');
+  const card = cards[0].rumor;
+  assert.equal(tagValue(card, 'type'), '2', 'Kind 16 Type 2 = payment request');
+  const paymentTag = paymentTagOf(card);
+  assert.ok(paymentTag, 'payment-request card has a payment tag');
   assert.equal(paymentTag[1], 'lightning', 'payment method is lightning');
-  // The crux of #7: the invoice in the event is the EXACT one generateInvoice
-  // returned — the single source of truth, not a divergent second invoice.
   assert.equal(
     paymentTag[2],
     FAKE_BOLT11,
-    'the event invoice is the one and only invoice generateInvoice returned'
+    'the card invoice is the one and only invoice generateInvoice returned'
+  );
+
+  // The kind-14 chat-note fallback.
+  const notes = giftWrapsOfKind(nostrClient, 14);
+  assert.equal(notes.length, 1, 'exactly one kind-14 invoice note sent');
+  const note = notes[0].rumor;
+  // The crux of #7: the kind-14 note embeds the EXACT same BOLT11 as the card —
+  // one invoice, two surfaces, so they can never diverge.
+  assert.ok(
+    note.content.includes(FAKE_BOLT11),
+    'the kind-14 note content carries the same BOLT11 as the card'
+  );
+  assert.equal(
+    paymentTag[2],
+    FAKE_BOLT11,
+    'card and note reference one and the same invoice (no second generateInvoice call)'
   );
 });
 
-test('NO separate NIP-04 (kind 4) invoice DM is sent during the order flow', async () => {
+test('the kind-14 note carries the SAME ["order", id] tag as the kind-16 card (correlatable/dedupable)', async () => {
   const order = buildOrderRumor();
   await handleOrder(order, nostrClient, { generateInvoice: generateInvoiceSpy });
 
+  const card = giftWrapsOfKind(nostrClient, 16)[0].rumor;
+  const note = giftWrapsOfKind(nostrClient, 14)[0].rumor;
+
+  const orderId = tagValue(order, 'order');
+  assert.equal(tagValue(card, 'order'), orderId, 'card carries the order id');
+  assert.equal(tagValue(note, 'order'), orderId, 'note carries the SAME order id');
+  // A client renders the card and suppresses the note by matching this tag.
   assert.equal(
-    nostrClient.dms.length,
-    0,
-    'the old separate NIP-04 invoice DM (formatInvoiceDM) must not be sent'
+    tagValue(note, 'order'),
+    tagValue(card, 'order'),
+    'card and note share an identical order tag so clients can dedupe at render time'
   );
-  // Defensive: even if a DM were sent, it must never carry the invoice.
-  for (const dm of nostrClient.dms) {
-    assert.ok(!String(dm.content).includes(FAKE_BOLT11), 'no DM may contain the BOLT11 invoice');
-  }
 });
 
-test('exactly one gift-wrapped payment request is sent to the buyer', async () => {
+test('exactly two gift wraps (one kind-16, one kind-14) go to the buyer, and NO kind-4 NIP-04 DM is used', async () => {
   const buyerPubkey = randomPubkey();
   const order = buildOrderRumor({ buyerPubkey });
   await handleOrder(order, nostrClient, { generateInvoice: generateInvoiceSpy });
 
-  assert.equal(nostrClient.giftWraps.length, 1, 'exactly one gift-wrapped message sent');
-  const { recipientPubkey, rumor } = nostrClient.giftWraps[0];
-  assert.equal(recipientPubkey, buyerPubkey, 'the payment request goes to the buyer');
-  assert.equal(tagValue(rumor, 'type'), '2', 'and it is the Type 2 payment request');
+  assert.equal(
+    nostrClient.giftWraps.length,
+    2,
+    'exactly two gift wraps sent for the initial request'
+  );
+  assert.equal(giftWrapsOfKind(nostrClient, 16).length, 1, 'one kind-16 card');
+  assert.equal(giftWrapsOfKind(nostrClient, 14).length, 1, 'one kind-14 note');
+  for (const { recipientPubkey } of nostrClient.giftWraps) {
+    assert.equal(recipientPubkey, buyerPubkey, 'both gift wraps go to the buyer');
+  }
+
+  // The old failure mode — a separate NIP-04 (kind 4) invoice DM — must be gone.
+  assert.equal(nostrClient.dms.length, 0, 'no NIP-04 (kind 4) DM is sent');
 });
 
-test('a duplicate order is skipped — no second invoice for the same order id', async () => {
+test('a duplicate order is skipped — no second invoice and no further gift wraps', async () => {
   const order = buildOrderRumor();
   await handleOrder(order, nostrClient, { generateInvoice: generateInvoiceSpy });
   // Replay the exact same order (same order id) — the persistent dedup store
-  // must short-circuit it, so no further invoice is generated.
+  // must short-circuit it, so no further invoice is generated and nothing resent.
   await handleOrder(order, nostrClient, { generateInvoice: generateInvoiceSpy });
 
   assert.equal(
@@ -188,5 +223,9 @@ test('a duplicate order is skipped — no second invoice for the same order id',
     1,
     'a replayed order must not generate a second invoice'
   );
-  assert.equal(nostrClient.giftWraps.length, 1, 'and must not send a second payment request');
+  assert.equal(
+    nostrClient.giftWraps.length,
+    2,
+    'a replayed order must not send any further gift wraps (still just the original card + note)'
+  );
 });

--- a/order-service/test/single-invoice.test.js
+++ b/order-service/test/single-invoice.test.js
@@ -17,8 +17,10 @@
  * enable double payment. No NIP-04 (kind 4) DM is used. This test locks that
  * invariant in so it cannot silently regress.
  *
- * Hermetic: the Lightning provider (`generateInvoice`) is injected as a spy and
- * the relay/publish layer is a fake `nostrClient`, so no network is touched.
+ * Hermetic: the Lightning provider (`generateInvoice`) is injected as a spy, the
+ * relay/publish layer is a fake `nostrClient`, and the dedup store is an in-memory
+ * stub — so no network is touched and the on-disk `.processed.json` is never read
+ * or written.
  *
  * Runs on Node's built-in test runner (no extra deps): `node --test`.
  */
@@ -48,8 +50,8 @@ function randomPubkey() {
 
 /**
  * Build a Kind 16 Type 1 order rumor — the unsigned inner event that
- * `unwrapGiftWrap` hands to `handleOrder`. A fresh `orderId` per call avoids the
- * persistent dedup store skipping the order as already-processed.
+ * `unwrapGiftWrap` hands to `handleOrder`. A fresh `orderId` per call keeps
+ * independent orders from colliding in the (injected) dedup store.
  */
 function buildOrderRumor({ buyerPubkey = randomPubkey(), amount = 5000 } = {}) {
   const orderId = randomBytes(16).toString('hex');
@@ -115,17 +117,35 @@ function giftWrapsOfKind(client, kind) {
   return client.giftWraps.filter((g) => g.rumor.kind === kind);
 }
 
+/**
+ * In-memory dedup store with the same shape as ProcessedStore (the bits
+ * handleOrder uses). Injected so the test never touches the on-disk
+ * `.processed.json`, keeping each run fully hermetic and isolated.
+ */
+function buildInMemoryStore() {
+  const orders = new Set();
+  const receipts = new Set();
+  return {
+    hasOrder: (id) => orders.has(id),
+    addOrder: (id) => orders.add(id),
+    hasReceipt: (id) => receipts.has(id),
+    addReceipt: (id) => receipts.add(id),
+  };
+}
+
 let nostrClient;
 let generateInvoiceSpy;
+let store;
 
 beforeEach(() => {
   nostrClient = buildFakeNostrClient();
   generateInvoiceSpy = buildGenerateInvoiceSpy();
+  store = buildInMemoryStore();
 });
 
 test('generateInvoice is called exactly once for a single order', async () => {
   const order = buildOrderRumor();
-  await handleOrder(order, nostrClient, { generateInvoice: generateInvoiceSpy });
+  await handleOrder(order, nostrClient, { generateInvoice: generateInvoiceSpy, store });
 
   assert.equal(
     generateInvoiceSpy.calls.length,
@@ -140,7 +160,7 @@ test('generateInvoice is called exactly once for a single order', async () => {
 
 test('the kind-16 card and the kind-14 note both carry the IDENTICAL invoice generateInvoice returned', async () => {
   const order = buildOrderRumor();
-  await handleOrder(order, nostrClient, { generateInvoice: generateInvoiceSpy });
+  await handleOrder(order, nostrClient, { generateInvoice: generateInvoiceSpy, store });
 
   // The kind-16 Type 2 payment-request card.
   const cards = giftWrapsOfKind(nostrClient, 16);
@@ -175,7 +195,7 @@ test('the kind-16 card and the kind-14 note both carry the IDENTICAL invoice gen
 
 test('the kind-14 note carries the SAME ["order", id] tag as the kind-16 card (correlatable/dedupable)', async () => {
   const order = buildOrderRumor();
-  await handleOrder(order, nostrClient, { generateInvoice: generateInvoiceSpy });
+  await handleOrder(order, nostrClient, { generateInvoice: generateInvoiceSpy, store });
 
   const card = giftWrapsOfKind(nostrClient, 16)[0].rumor;
   const note = giftWrapsOfKind(nostrClient, 14)[0].rumor;
@@ -194,7 +214,7 @@ test('the kind-14 note carries the SAME ["order", id] tag as the kind-16 card (c
 test('exactly two gift wraps (one kind-16, one kind-14) go to the buyer, and NO kind-4 NIP-04 DM is used', async () => {
   const buyerPubkey = randomPubkey();
   const order = buildOrderRumor({ buyerPubkey });
-  await handleOrder(order, nostrClient, { generateInvoice: generateInvoiceSpy });
+  await handleOrder(order, nostrClient, { generateInvoice: generateInvoiceSpy, store });
 
   assert.equal(
     nostrClient.giftWraps.length,
@@ -213,10 +233,10 @@ test('exactly two gift wraps (one kind-16, one kind-14) go to the buyer, and NO 
 
 test('a duplicate order is skipped — no second invoice and no further gift wraps', async () => {
   const order = buildOrderRumor();
-  await handleOrder(order, nostrClient, { generateInvoice: generateInvoiceSpy });
+  await handleOrder(order, nostrClient, { generateInvoice: generateInvoiceSpy, store });
   // Replay the exact same order (same order id) — the persistent dedup store
   // must short-circuit it, so no further invoice is generated and nothing resent.
-  await handleOrder(order, nostrClient, { generateInvoice: generateInvoiceSpy });
+  await handleOrder(order, nostrClient, { generateInvoice: generateInvoiceSpy, store });
 
   assert.equal(
     generateInvoiceSpy.calls.length,


### PR DESCRIPTION
## What and why

Issue #7: *"DM invoice may be different from website invoice (double payment possible)."*

The **old** architecture sent **two independently-generated** invoices for one order — a Kind 16 Type 2 payment request (website) **and** a separate NIP-04 (kind 4) DM invoice (`formatInvoiceDM`). Those two BOLT11 strings could diverge, so a buyer could pay both and lose funds (double payment).

This PR makes the order-service deliver **one** invoice on **two surfaces**, both gift-wrapped to the buyer, so they can never diverge — and adds a regression test (wired into CI) that locks the invariant in.

## What changed

`handleOrder()` (`order-service/index.js`) generates exactly **one** Lightning invoice (one `generateInvoice` call) and sends it two ways:

1. **kind 16 Type 2** payment-request card (unchanged) — the rich, structured "order card" rendered by Gamma-aware clients and the website.
2. **kind 14** chat note (new) carrying the **same BOLT11** plus the **same `["order", <id>]` tag** — a fallback so generic NIP-17 DM clients (0xchat, Amethyst's DM view) that can't draw a kind 16 card still show the invoice.

Why it's safe re #7: it's the **same** BOLT11 on both surfaces (no second `generateInvoice`), so a single Lightning invoice settles **once** — even if a buyer pays from both, the second settle fails at the Lightning layer. No NIP-04 (kind 4) DM is used. The shared `["order", <id>]` tag lets rich clients correlate the two and suppress the duplicate.

### Files

- **`order-service/index.js`** — added a `formatInvoiceChatNote()` helper and the kind-14 gift-wrap on the initial payment request only (not status/shipping updates). `handleOrder` is exported and takes an optional injected `generateInvoice` (defaulting to the real LNURL impl); `main()` is guarded behind an entry-point check so importing the module has no network side effects.
- **`order-service/test/single-invoice.test.js`** (new) — hermetic regression test (Node built-in runner, no network).
- **`.github/workflows/ci.yml`** — new **`Order Service Tests`** job (see below).
- **`README.md`** — updated the order-flow Mermaid diagram to show the dual delivery, and added a *"One invoice, two surfaces — how clients ignore the duplicate"* section documenting the dedup contract for client authors.

## Making sure the test actually runs in CI

The root Vitest config **excludes `order-service/**`**, and no existing workflow ran the order-service suite — so a test under `order-service/` would **never** execute in the main "Unit Tests" job. The order-service has its own `node --test` suite (`order-service/package.json` -> `"test": "node --test"`), so the minimal correct fix is a dedicated job. The new **`Order Service Tests`** job runs `npm ci` + `npm test` in `order-service/`, and the **`Build`** job now `needs` it, so the regression test is genuinely enforced on every PR. (Confirmed in CI: the 5 assertions run as tests 17–21 of that job.)

## Test plan

- `cd order-service && npm test` (= `node --test`) — the new `single-invoice.test.js` and all existing order-service tests pass (21 total). It asserts, for a single placed order:
  1. `generateInvoice` is called **exactly once**.
  2. The kind-16 `bolt11` tag and the kind-14 note content **both contain the identical BOLT11**.
  3. The kind-14 note carries the **same `["order", <id>]` tag** as the kind-16 card.
  4. **Exactly two** gift wraps are sent (one kind-16, one kind-14) and **no kind-4** NIP-04 DM.
  5. A replayed order generates no second invoice and no further gift wraps (dedup store).
- Root gates pass locally: `npm run typecheck`, `npm run lint` (0 errors), `npm run format:check`, `npx vitest run` (109 tests).

Test-run output (the new regression test):

```
ok 1 - generateInvoice is called exactly once for a single order
ok 2 - the kind-16 card and the kind-14 note both carry the IDENTICAL invoice generateInvoice returned
ok 3 - the kind-14 note carries the SAME ["order", id] tag as the kind-16 card (correlatable/dedupable)
ok 4 - exactly two gift wraps (one kind-16, one kind-14) go to the buyer, and NO kind-4 NIP-04 DM is used
ok 5 - a duplicate order is skipped — no second invoice and no further gift wraps
# tests 5
# suites 0
# pass 5
# fail 0
```

Fixes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)