### PR TITLE
fix: signed-out zap affordance on story replies

### DIFF
--- a/src/components/FollowUsButton.tsx
+++ b/src/components/FollowUsButton.tsx
@@ -42,8 +42,11 @@ interface FollowUsButtonProps {
  *
  * - Signed in: reads the current kind-3 on mount to show "Following" when already
  *   following; clicking publishes an updated kind-3 and toasts on success.
- * - Signed out: opens the LoginDialog (auto-following once signed in) and always
- *   offers a "View on Nostr" fallback link so the shop can be followed externally.
+ * - Signed out: opens the LoginDialog (auto-following once signed in) and, when
+ *   {@link FollowUsButtonProps.showViewOnNostr} is enabled (the default), offers
+ *   a "View on Nostr" fallback link so the shop can be followed externally. The
+ *   story hero passes `showViewOnNostr={false}` since its action row links out
+ *   elsewhere.
  */
 export function FollowUsButton({
   className,

--- a/src/components/StoryReplies.tsx
+++ b/src/components/StoryReplies.tsx
@@ -79,7 +79,7 @@ export function StoryReplies({ note }: { note: NostrEvent }) {
       ) : replies.length > 0 ? (
         <div className="space-y-4">
           {replies.map((reply) => (
-            <StoryReply key={reply.id} event={reply} />
+            <StoryReply key={reply.id} event={reply} onRequireLogin={() => setShowLogin(true)} />
           ))}
         </div>
       ) : (

--- a/src/components/StoryReply.test.tsx
+++ b/src/components/StoryReply.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { NostrEvent } from '@nostrify/nostrify';
+import { TestApp } from '@/test/TestApp';
+import { StoryReply } from './StoryReply';
+
+function makeReply(): NostrEvent {
+  return {
+    id: 'a'.repeat(64),
+    pubkey: 'b'.repeat(64),
+    created_at: Math.floor(Date.now() / 1000) - 1800,
+    kind: 1,
+    tags: [],
+    content: 'Looks great — nice print!',
+    sig: 'c'.repeat(128),
+  };
+}
+
+describe('StoryReply (signed out)', () => {
+  it('renders the reply text and a sign-in-gated Zap affordance', () => {
+    render(
+      <TestApp>
+        <StoryReply event={makeReply()} />
+      </TestApp>
+    );
+    expect(screen.getByText(/looks great — nice print/i)).toBeInTheDocument();
+    // Signed-out visitors get a Zap affordance (which prompts sign-in on click),
+    // matching the per-post and hero zap pattern rather than rendering nothing.
+    expect(screen.getByRole('button', { name: /zap/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/StoryReply.test.tsx
+++ b/src/components/StoryReply.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen, fireEvent, within } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
 import type { NostrEvent } from '@nostrify/nostrify';
 import { TestApp } from '@/test/TestApp';
 import { StoryReply } from './StoryReply';
@@ -20,7 +20,7 @@ describe('StoryReply (signed out)', () => {
   it('renders the reply text and a sign-in-gated Zap affordance', () => {
     render(
       <TestApp>
-        <StoryReply event={makeReply()} />
+        <StoryReply event={makeReply()} onRequireLogin={() => {}} />
       </TestApp>
     );
     expect(screen.getByText(/looks great — nice print/i)).toBeInTheDocument();
@@ -29,18 +29,17 @@ describe('StoryReply (signed out)', () => {
     expect(screen.getByRole('button', { name: /zap/i })).toBeInTheDocument();
   });
 
-  it('opens the sign-in dialog when a signed-out visitor clicks Zap', async () => {
+  it('calls onRequireLogin when a signed-out visitor clicks Zap', () => {
+    const onRequireLogin = vi.fn();
     render(
       <TestApp>
-        <StoryReply event={makeReply()} />
+        <StoryReply event={makeReply()} onRequireLogin={onRequireLogin} />
       </TestApp>
     );
-    // Clicking the signed-out Zap affordance must open LoginDialog (not zap) —
-    // proving the gating, since a signed-in render would show the real ZapButton.
+    // Clicking the signed-out Zap affordance asks the parent (which owns the one
+    // shared LoginDialog) to prompt sign-in — proving the gating, since a
+    // signed-in render would show the real ZapButton instead.
     fireEvent.click(screen.getByRole('button', { name: /zap/i }));
-    const dialog = await screen.findByRole('dialog');
-    expect(dialog).toBeInTheDocument();
-    // Confirm it's the login dialog specifically (offers a sign-up path).
-    expect(within(dialog).getByRole('button', { name: /sign up/i })).toBeInTheDocument();
+    expect(onRequireLogin).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/StoryReply.test.tsx
+++ b/src/components/StoryReply.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import type { NostrEvent } from '@nostrify/nostrify';
 import { TestApp } from '@/test/TestApp';
 import { StoryReply } from './StoryReply';
@@ -27,5 +27,20 @@ describe('StoryReply (signed out)', () => {
     // Signed-out visitors get a Zap affordance (which prompts sign-in on click),
     // matching the per-post and hero zap pattern rather than rendering nothing.
     expect(screen.getByRole('button', { name: /zap/i })).toBeInTheDocument();
+  });
+
+  it('opens the sign-in dialog when a signed-out visitor clicks Zap', async () => {
+    render(
+      <TestApp>
+        <StoryReply event={makeReply()} />
+      </TestApp>
+    );
+    // Clicking the signed-out Zap affordance must open LoginDialog (not zap) —
+    // proving the gating, since a signed-in render would show the real ZapButton.
+    fireEvent.click(screen.getByRole('button', { name: /zap/i }));
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+    // Confirm it's the login dialog specifically (offers a sign-up path).
+    expect(within(dialog).getByRole('button', { name: /sign up/i })).toBeInTheDocument();
   });
 });

--- a/src/components/StoryReply.tsx
+++ b/src/components/StoryReply.tsx
@@ -1,11 +1,15 @@
+import { useState } from 'react';
 import type { NostrEvent } from '@nostrify/nostrify';
 import { formatDistanceToNow } from 'date-fns';
 import { nip19 } from 'nostr-tools';
+import { Zap } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { NoteContent } from '@/components/NoteContent';
 import { ZapButton } from '@/components/ZapButton';
+import LoginDialog from '@/components/auth/LoginDialog';
 import { useAuthor } from '@/hooks/useAuthor';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { genUserName } from '@/lib/genUserName';
 
 /**
@@ -15,6 +19,8 @@ import { genUserName } from '@/lib/genUserName';
  */
 export function StoryReply({ event }: { event: NostrEvent }) {
   const author = useAuthor(event.pubkey);
+  const { user } = useCurrentUser();
+  const [showLogin, setShowLogin] = useState(false);
   const metadata = author.data?.metadata;
   const name = metadata?.display_name || metadata?.name || genUserName(event.pubkey);
   const npub = nip19.npubEncode(event.pubkey);
@@ -42,13 +48,34 @@ export function StoryReply({ event }: { event: NostrEvent }) {
           event={event}
           className="mt-0.5 text-sm text-sage-700 dark:text-sage-200 leading-relaxed"
         />
+        {/* Zap the reply (NIP-57). Signed-in users see the real ZapButton (which
+            self-hides on a self-zap or an author with no lightning address);
+            signed-out users get a Zap affordance that opens the sign-in dialog —
+            the same login-gated pattern as posts and the hero. */}
         <div className="mt-1">
-          <ZapButton
-            target={event}
-            className="text-xs text-sage-500 hover:text-robotechy-green-dark"
-          />
+          {user ? (
+            <ZapButton
+              target={event}
+              className="text-xs text-sage-500 hover:text-robotechy-green-dark"
+            />
+          ) : (
+            <button
+              type="button"
+              onClick={() => setShowLogin(true)}
+              className="flex items-center gap-1 text-xs text-sage-500 transition-colors hover:text-robotechy-green-dark"
+            >
+              <Zap className="h-4 w-4" />
+              <span>Zap</span>
+            </button>
+          )}
         </div>
       </div>
+
+      <LoginDialog
+        isOpen={showLogin}
+        onClose={() => setShowLogin(false)}
+        onLogin={() => setShowLogin(false)}
+      />
     </div>
   );
 }

--- a/src/components/StoryReply.tsx
+++ b/src/components/StoryReply.tsx
@@ -56,13 +56,13 @@ export function StoryReply({ event }: { event: NostrEvent }) {
           {user ? (
             <ZapButton
               target={event}
-              className="text-xs text-sage-500 hover:text-robotechy-green-dark"
+              className="text-xs text-sage-500 hover:text-robotechy-green-dark dark:text-sage-300"
             />
           ) : (
             <button
               type="button"
               onClick={() => setShowLogin(true)}
-              className="flex items-center gap-1 text-xs text-sage-500 transition-colors hover:text-robotechy-green-dark"
+              className="flex items-center gap-1 text-xs text-sage-500 transition-colors hover:text-robotechy-green-dark dark:text-sage-300"
             >
               <Zap className="h-4 w-4" />
               <span>Zap</span>

--- a/src/components/StoryReply.tsx
+++ b/src/components/StoryReply.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import type { NostrEvent } from '@nostrify/nostrify';
 import { formatDistanceToNow } from 'date-fns';
 import { nip19 } from 'nostr-tools';
@@ -7,20 +6,25 @@ import { Link } from 'react-router-dom';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { NoteContent } from '@/components/NoteContent';
 import { ZapButton } from '@/components/ZapButton';
-import LoginDialog from '@/components/auth/LoginDialog';
 import { useAuthor } from '@/hooks/useAuthor';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { genUserName } from '@/lib/genUserName';
+
+interface StoryReplyProps {
+  event: NostrEvent;
+  /** Called when a signed-out visitor taps the Zap affordance. The parent owns
+   *  a single shared LoginDialog rather than one dialog per reply. */
+  onRequireLogin: () => void;
+}
 
 /**
  * A single reply (kind-1) shown under a story post: the commenter's avatar and
  * name (from their kind-0 metadata), a relative timestamp, the linkified reply
  * text, and a zap affordance for the reply itself.
  */
-export function StoryReply({ event }: { event: NostrEvent }) {
+export function StoryReply({ event, onRequireLogin }: StoryReplyProps) {
   const author = useAuthor(event.pubkey);
   const { user } = useCurrentUser();
-  const [showLogin, setShowLogin] = useState(false);
   const metadata = author.data?.metadata;
   const name = metadata?.display_name || metadata?.name || genUserName(event.pubkey);
   const npub = nip19.npubEncode(event.pubkey);
@@ -61,7 +65,7 @@ export function StoryReply({ event }: { event: NostrEvent }) {
           ) : (
             <button
               type="button"
-              onClick={() => setShowLogin(true)}
+              onClick={onRequireLogin}
               className="flex items-center gap-1 text-xs text-sage-500 transition-colors hover:text-robotechy-green-dark dark:text-sage-300"
             >
               <Zap className="h-4 w-4" />
@@ -70,12 +74,6 @@ export function StoryReply({ event }: { event: NostrEvent }) {
           )}
         </div>
       </div>
-
-      <LoginDialog
-        isOpen={showLogin}
-        onClose={() => setShowLogin(false)}
-        onLogin={() => setShowLogin(false)}
-      />
     </div>
   );
 }


### PR DESCRIPTION
Fixes #35

Forward-ports two commits that were stranded on `feat/story-feed` after PR #32 was merged.

## What
- **`fix: signed-out zap affordance on story replies`** — story replies now show the same sign-in-prompt zap affordance to signed-out visitors that posts and the shop hero already had (they previously only showed the zap button when signed in). Mirrors `StoryNote`/`StoryReply` patterns; adds a render test.
- **`docs: clarify FollowUsButton View-on-Nostr is gated by showViewOnNostr`** — corrects a now-inaccurate JSDoc after the hero dropped its "View on Nostr" link.

Both arrived after #32 was merged, so they couldn't land on that (now-immutable) PR.

## Test plan
- Unit: `src/components/StoryReply.test.tsx` asserts a signed-out visitor sees the zap (sign-in) affordance on a reply.
- Existing story tests + e2e remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)