### PR TITLE
test: update reviews + story e2e scripts for tabs and per-reply zap

### DIFF
--- a/e2e/product-reviews.mjs
+++ b/e2e/product-reviews.mjs
@@ -56,13 +56,19 @@ async function injectLogin(page, nsec) {
 async function gotoFirstProduct(page) {
   await page.goto(BASE_URL + '/', { waitUntil: 'networkidle', timeout: 30000 });
   await page.waitForTimeout(1500);
-  // Product cards link to /<naddr>. Click the first one.
+  // Product cards link to /<naddr>. Navigate to the first one directly (the
+  // card image overlay can intercept a click, so resolve the href and goto).
   const firstProduct = page.locator('a[href^="/naddr1"]').first();
   await firstProduct.waitFor({ timeout: 15000 });
-  await firstProduct.click();
+  const href = await firstProduct.getAttribute('href');
+  if (!href) {
+    throw new Error('First product card has no href — cannot navigate to the product page.');
+  }
+  await page.goto(BASE_URL + href, { waitUntil: 'networkidle', timeout: 30000 });
   await page.waitForTimeout(1500);
-  // The reviews section heading confirms we're on a product page.
-  await page.getByRole('heading', { name: /reviews/i }).first().waitFor({ timeout: 15000 });
+  // Reviews + Comments are tabs (Reviews is the default active tab). The
+  // Reviews tab confirms we're on a product page with the feedback tabs mounted.
+  await page.getByRole('tab', { name: /reviews/i }).first().waitFor({ timeout: 15000 });
 }
 
 const browser = await chromium.launch({ headless: HEADLESS, args: ['--no-sandbox'] });
@@ -72,8 +78,8 @@ const browser = await chromium.launch({ headless: HEADLESS, args: ['--no-sandbox
   const page = await browser.newPage({ viewport: { width: 1280, height: 1100 } });
   await gotoFirstProduct(page);
 
-  const reviewsHeading = page.getByRole('heading', { name: /reviews/i }).first();
-  await reviewsHeading.scrollIntoViewIfNeeded();
+  const reviewsTab = page.getByRole('tab', { name: /reviews/i }).first();
+  await reviewsTab.scrollIntoViewIfNeeded();
   await page.waitForTimeout(500);
 
   // The "Sign in to review" button must open the LoginDialog (not no-op).
@@ -96,8 +102,8 @@ if (NSEC) {
   await injectLogin(page, NSEC);
   await gotoFirstProduct(page);
 
-  const reviewsHeading = page.getByRole('heading', { name: /reviews/i }).first();
-  await reviewsHeading.scrollIntoViewIfNeeded();
+  const reviewsTab = page.getByRole('tab', { name: /reviews/i }).first();
+  await reviewsTab.scrollIntoViewIfNeeded();
   await page.waitForTimeout(500);
 
   // Pick 4 stars (the picker is an ARIA radiogroup of star buttons).
@@ -112,7 +118,7 @@ if (NSEC) {
   await page.getByText(text).first().waitFor({ timeout: 20000 });
   console.log('signed-in: kind-31555 review published and rendered OK');
 
-  await reviewsHeading.scrollIntoViewIfNeeded();
+  await reviewsTab.scrollIntoViewIfNeeded();
   await page.waitForTimeout(1000);
   if (SHOT_DIR) await page.screenshot({ path: `${SHOT_DIR}/03-just-submitted.png` });
   await page.close();

--- a/e2e/story.mjs
+++ b/e2e/story.mjs
@@ -128,8 +128,10 @@ let hasPosts = false;
         .textContent()) || '';
     console.log(`replies section OK on first post — ${repliesLabel.trim()}`);
 
-    // Signed-out zap affordance + sign-in-gated reply composer.
-    await first.getByRole('button', { name: /^zap$/i }).waitFor({ timeout: 5000 });
+    // Signed-out zap affordance + sign-in-gated reply composer. The post's own
+    // ZapButton renders before the replies (which now each carry their own zap),
+    // so scope to the first match — the post's — to stay out of strict mode.
+    await first.getByRole('button', { name: /^zap$/i }).first().waitFor({ timeout: 5000 });
     const replyBtn = first.getByRole('button', { name: /sign in to reply/i });
     await replyBtn.waitFor({ timeout: 5000 });
     console.log('signed-out: Zap + "Sign in to reply" affordances present OK');


### PR DESCRIPTION
## What

Fixes two manual Playwright smoke scripts (`e2e/*.mjs`) that broke against changes already on `main`. Both were **stale test-script selectors**, not app bugs — the app behaviour is correct.

### `e2e/product-reviews.mjs`
Two failures, both from the product-feedback UI moving Reviews/Comments into **tabs** (`ProductFeedbackTabs`, `ReviewsSection` rendered with `hideHeading`):
- **Removed heading** — the script anchored on `getByRole('heading', /reviews/i)`, which no longer exists. Now anchors on the Reviews **tab** (the default active tab, so no tab-switch needed).
- **Click intercepted** — clicking the product card was swallowed by the card's hover-scale `<img>` overlay. Now resolves the link's `href` and navigates directly — the same approach `product-comments.mjs` already uses.

### `e2e/story.mjs`
- **Playwright strict-mode violation** — `StoryReply` now renders its own Zap button per reply, so the first post's `<li>` matched multiple "Zap" buttons. Scoped the assertion to `.first()`; verified in `StoryNote.tsx` that the post's own `ZapButton` renders *before* `StoryReplies`, so `.first()` targets the post's zap, not a reply's. Signed-in phase selectors (`Write a reply…` composer, `Reply` button) remain unique — no change needed.

## Testing

All six signed-out e2e flows pass locally against the dev server:

```
search-flow:       PASS
follow-us:         PASS
share-product:     PASS
product-reviews:   PASS   (was failing 3/3)
product-comments:  PASS
story:             PASS   (was strict-mode violation)
```

Signed-in phases were not run (they publish live Nostr events and need a throwaway `NSEC`). These scripts are not part of CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Test plan
- Run the updated e2e scripts (`e2e/product-reviews.mjs`, `e2e/story.mjs`) against the dev server; they drive the Reviews/Comments tabs and the per-reply zap and pass.