### PR TITLE
fix: order-service survives relay 403 handshake rejections + entrypoint supervises both processes

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -25,25 +25,42 @@ echo "Starting frontend on port 3000..."
 serve -s dist -l 3000 &
 SERVE_PID=$!
 
-# Forward docker stop / ctrl-c to the children, then exit cleanly.
+# A child that exited but hasn't been reaped yet (zombie, state Z) still
+# passes `kill -0`, so check the /proc state too — otherwise the supervisor
+# could briefly mistake a dead service for a live one. (The shell does reap
+# children while blocked in `wait` below, so a zombie can't persist across
+# iterations, but this closes the race window entirely.)
+is_alive() {
+  kill -0 "$1" 2>/dev/null || return 1
+  # /proc/<pid>/stat is `pid (comm) state ...`; strip through the last `) `
+  # to read the state field (comm itself may contain spaces or parens).
+  state=$(awk '{ sub(/.*\) /, ""); print substr($0, 1, 1) }' "/proc/$1/stat" 2>/dev/null)
+  [ "$state" != "Z" ]
+}
+
+# Forward docker stop / ctrl-c to the children, then exit cleanly. Every kill
+# is `|| true`-guarded: under `set -e` a kill of an already-dead child would
+# otherwise abort the trap before the clean `exit 0`.
 shutdown() {
   echo "Shutting down..."
-  [ -n "$ORDER_PID" ] && kill "$ORDER_PID" 2>/dev/null
-  kill "$SERVE_PID" 2>/dev/null
+  if [ -n "$ORDER_PID" ]; then kill "$ORDER_PID" 2>/dev/null || true; fi
+  kill "$SERVE_PID" 2>/dev/null || true
   exit 0
 }
 trap shutdown TERM INT
 
 # Supervise: if either process dies, take the container down with it.
 while :; do
-  if [ -n "$ORDER_PID" ] && ! kill -0 "$ORDER_PID" 2>/dev/null; then
+  if [ -n "$ORDER_PID" ] && ! is_alive "$ORDER_PID"; then
     echo "Order service exited - stopping container so Docker restarts it"
-    kill "$SERVE_PID" 2>/dev/null
+    wait "$ORDER_PID" 2>/dev/null || true # reap if zombie
+    kill "$SERVE_PID" 2>/dev/null || true
     exit 1
   fi
-  if ! kill -0 "$SERVE_PID" 2>/dev/null; then
+  if ! is_alive "$SERVE_PID"; then
     echo "Frontend exited - stopping container so Docker restarts it"
-    [ -n "$ORDER_PID" ] && kill "$ORDER_PID" 2>/dev/null
+    wait "$SERVE_PID" 2>/dev/null || true # reap if zombie
+    if [ -n "$ORDER_PID" ]; then kill "$ORDER_PID" 2>/dev/null || true; fi
     exit 1
   fi
   # Background sleep + wait keeps the TERM/INT trap responsive mid-interval.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,6 +4,7 @@ set -e
 echo "Starting Robotechy services..."
 
 # Start order service in background (if env vars are set)
+ORDER_PID=""
 if [ -n "$MERCHANT_NSEC" ] && [ -n "$LIGHTNING_ADDRESS" ]; then
   echo "Starting order processing service..."
   cd /app/order-service
@@ -15,6 +16,39 @@ else
   echo "Warning: MERCHANT_NSEC or LIGHTNING_ADDRESS not set - order service disabled"
 fi
 
-# Start frontend static server
+# Start frontend static server (backgrounded — the shell stays PID 1 so it can
+# supervise BOTH children; the previous `exec serve` left the container looking
+# "healthy" with a dead order service, which is how a backend crash went
+# unnoticed in production. If either child dies, exit so Docker's restart
+# policy revives the whole container.)
 echo "Starting frontend on port 3000..."
-exec serve -s dist -l 3000
+serve -s dist -l 3000 &
+SERVE_PID=$!
+
+# Forward docker stop / ctrl-c to the children, then exit cleanly.
+shutdown() {
+  echo "Shutting down..."
+  [ -n "$ORDER_PID" ] && kill "$ORDER_PID" 2>/dev/null
+  kill "$SERVE_PID" 2>/dev/null
+  exit 0
+}
+trap shutdown TERM INT
+
+# Supervise: if either process dies, take the container down with it.
+while :; do
+  if [ -n "$ORDER_PID" ] && ! kill -0 "$ORDER_PID" 2>/dev/null; then
+    echo "Order service exited - stopping container so Docker restarts it"
+    kill "$SERVE_PID" 2>/dev/null
+    exit 1
+  fi
+  if ! kill -0 "$SERVE_PID" 2>/dev/null; then
+    echo "Frontend exited - stopping container so Docker restarts it"
+    [ -n "$ORDER_PID" ] && kill "$ORDER_PID" 2>/dev/null
+    exit 1
+  fi
+  # Background sleep + wait keeps the TERM/INT trap responsive mid-interval.
+  # (|| true: a trap-interrupted wait returns non-zero, which must not trip
+  # set -e and kill PID 1.)
+  sleep 5 &
+  wait $! || true
+done

--- a/order-service/lib/relayErrors.js
+++ b/order-service/lib/relayErrors.js
@@ -20,6 +20,13 @@ const RELAY_NOISE = [
   'network error',
   'non-101',
   'websocket',
+  // ws's handshake failure ("Unexpected server response: 403") when a relay
+  // refuses the WebSocket upgrade with an HTTP status. Raised on an internal
+  // nostr-tools connection promise nobody awaits, so it reaches this handler
+  // (and crashed the service in production on 2026-07-02). The phrase is
+  // specific to ws's upgrade path — the LNURL/Lightning fetch path can never
+  // produce it — so matching it cannot swallow a real payment error.
+  'unexpected server response',
   // Specific connection/socket phrases only — a bare 'connection' or 'timeout'
   // would swallow unrelated failures (e.g. a Lightning/LNURL HTTP timeout, which
   // is a real error). Relay/socket timeouts reaching this handler always carry a

--- a/order-service/test/relayErrors.test.js
+++ b/order-service/test/relayErrors.test.js
@@ -11,6 +11,13 @@ test('ignores the "connection timed out" rejection that previously crashed the s
   assert.equal(isIgnorableRelayError('connection timed out'), true);
 });
 
+test('ignores the ws handshake rejection ("Unexpected server response: 403") that crashed the service in production', () => {
+  // A relay refusing the WebSocket upgrade rejects an internal nostr-tools
+  // connection promise nobody awaits — it must be classified as relay noise.
+  assert.equal(isIgnorableRelayError(new Error('Unexpected server response: 403')), true);
+  assert.equal(isIgnorableRelayError(new Error('Unexpected server response: 502')), true);
+});
+
 test('ignores known transient relay/network errors (case-insensitive)', () => {
   for (const m of [
     'restricted: Pay on https://nostr.land for access.',


### PR DESCRIPTION
Fixes #41

## What

Fixes the production order-service crash observed on black-panther (2026-07-02) right after deploying latest `main`:

```
[Order] Sending gift-wrapped kind-14 invoice note to buyer...
[Fatal] Unhandled rejection: Unexpected server response: 403
```

The order-service `node` process died (zombie), while the container kept running "healthy" because the frontend (`serve`) was PID 1 — storefront up, **order/invoice processing silently down**.

## Root cause

1. **Crash**: a relay refused the WebSocket upgrade; `ws` raises `Unexpected server response: 403` on an internal nostr-tools connection promise that nothing awaits (it bypasses the `Promise.allSettled` in `sendGiftWrap`), so it surfaces as a global unhandled rejection. The `isIgnorableRelayError` classifier covers `websocket`, `non-101`, `connection timed out`, etc. — but not this phrase — so the handler treated it as a genuine bug and `process.exit(1)`'d.
2. **Silent failure**: `docker-entrypoint.sh` ran `exec serve`, making the frontend PID 1. The order service died as an unmonitored background child: `RestartCount=0`, container "Up", orders down.

## Fixes

- **`order-service/lib/relayErrors.js`** — add `unexpected server response` to `RELAY_NOISE`. The phrase is specific to ws's handshake path — the LNURL/Lightning fetch path can never produce it — so it cannot swallow a real payment error. Same pattern as the previous "connection timed out" incident already documented in that file.
- **`order-service/test/relayErrors.test.js`** — regression test pinning the exact production message (`403`, plus `502`).
- **`docker-entrypoint.sh`** — the shell now stays PID 1 and supervises *both* children: if either the order service or the frontend dies, the container exits so `restart: unless-stopped` revives it (visible crash-loop instead of silent zombie). TERM/INT are trapped and forwarded so `docker stop` stays clean.

## Test plan

1. `cd order-service && node --test` — all 22 tests pass, including the new regression test that pins the exact production crash message (`Unexpected server response: 403` → classified ignorable; genuine errors like `orderId is required` remain fatal).
2. `sh -n docker-entrypoint.sh` — syntax check passes.
3. Entrypoint supervision, simulated with mock child processes:
   - kill the "order service" child → supervisor detects it and exits 1 (Docker's `restart: unless-stopped` then revives the container);
   - send SIGTERM (as `docker stop` does) → both children are killed and the script exits 0.
4. After merge, rebuild on black-panther (`docker compose up -d --build robotechy`) and verify: `docker compose exec robotechy ps` shows the shell as PID 1 with `serve` **and** `node index.js` as children; `curl localhost:8084` returns 200; logs show the order service polling.

## Deploy note

After merge, the black-panther container needs a rebuild (`docker compose up -d --build robotechy`) to pick this up — the current production container was revived by a restart but still runs the unfixed image, so a future relay 403 would kill order processing again until this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TkQZwPZF2imue3DBJ4X1Ex
