### PR TITLE
fix: persist order-service dedup store across container rebuilds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,9 @@ coverage/
 order-service/.env
 order-service/.env.test
 
-# Order-service persisted dedup store (processed order/receipt IDs)
+# Order-service persisted dedup store (processed order/receipt IDs). Lives in
+# data/ so a Docker volume can be mounted there (survives container rebuilds).
+order-service/data/
 order-service/.processed.json
 
 # IDE

--- a/docs/DEPLOYMENT.adoc
+++ b/docs/DEPLOYMENT.adoc
@@ -105,5 +105,11 @@ docker compose up -d --build robotechy   # after main points at the good commit
 * Service `robotechy` in `apps-stack/docker-compose.yml`, published on `8084:3000`.
 * Env: `MERCHANT_NSEC`, `LIGHTNING_ADDRESS`, `FALLBACK_RELAYS` (order service);
   without the first two it runs frontend-only.
+* Volume: mount a named volume at `/app/order-service/data` — it holds the
+  order-service dedup store (`.processed.json`), which must survive container
+  *rebuilds* (not just restarts). Without it, every deploy wipes the store and
+  the service re-invoices up to 2 days of already-processed orders, sending
+  buyers duplicate payment-request DMs. (`PROCESSED_STORE_PATH` overrides the
+  store path if a different layout is needed.)
 * See link:INSTALLATION.adoc#_docker_deployment[Installation → Docker Deployment]
   for the image details and link:TROUBLESHOOTING.adoc[Troubleshooting].

--- a/order-service/lib/processedStore.js
+++ b/order-service/lib/processedStore.js
@@ -14,14 +14,21 @@
  * keeps the file bounded.
  */
 
-import { readFileSync, writeFileSync, existsSync, renameSync, rmSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync, renameSync, rmSync, mkdirSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-// Default location: order-service/.processed.json (gitignored).
-export const DEFAULT_STORE_PATH = join(__dirname, '..', '.processed.json');
+// Default location: order-service/data/.processed.json (gitignored). The store
+// lives in a dedicated data/ directory — not next to the code — so a Docker
+// deployment can mount a volume at that directory and the dedup state survives
+// container REBUILDS, not just restarts. (Without the volume, every rebuild
+// wiped the store and re-invoiced up to 2 days of orders — buyers received
+// duplicate payment-request DMs after each deploy.) Override with
+// PROCESSED_STORE_PATH for non-default layouts.
+export const DEFAULT_STORE_PATH =
+  process.env.PROCESSED_STORE_PATH || join(__dirname, '..', 'data', '.processed.json');
 
 export class ProcessedStore {
   /**
@@ -88,6 +95,9 @@ export class ProcessedStore {
         orders: Object.fromEntries(this.orders),
         receipts: Object.fromEntries(this.receipts),
       };
+      // The data/ directory may not exist yet (fresh checkout, or an empty
+      // just-created Docker volume) — create it before the first write.
+      mkdirSync(dirname(this.filePath), { recursive: true });
       writeFileSync(tmpPath, JSON.stringify(data), 'utf-8');
       renameSync(tmpPath, this.filePath);
     } catch (error) {

--- a/order-service/test/processedStore.test.js
+++ b/order-service/test/processedStore.test.js
@@ -18,6 +18,21 @@ function tmpFile() {
   return { path: join(dir, '.processed.json'), dir };
 }
 
+test('creates a missing parent directory on first save (fresh data/ dir or empty volume)', () => {
+  const { dir } = tmpFile();
+  try {
+    // Point the store at a path whose parent directory does not exist yet —
+    // exactly the state of a fresh checkout or a just-created Docker volume.
+    const nested = join(dir, 'data', '.processed.json');
+    const store = new ProcessedStore(nested, 0);
+    store.addOrder('order-1'); // must not warn/fail — save() mkdirs the parent
+    const reloaded = new ProcessedStore(nested, 0);
+    assert.equal(reloaded.hasOrder('order-1'), true, 'store should persist into the created dir');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('processed IDs survive a restart (persisted to disk)', () => {
   const { path, dir } = tmpFile();
   try {


### PR DESCRIPTION
Fixes #42

## What

Every container **rebuild** (i.e. every deploy) wiped the order-service dedup store, so the 2-day gift-wrap lookback re-processed already-invoiced orders and buyers received **duplicate payment-request DMs**. Observed in production right after the #40 deploy (order `e2513f15` re-invoiced).

## Changes

- **`order-service/lib/processedStore.js`** — default store path moves from `order-service/.processed.json` (next to the code — impossible to volume-mount without shadowing the code) to a dedicated **`order-service/data/`** directory, so production can mount a named volume at `/app/order-service/data`. `save()` now creates the directory on first write (fresh checkout or empty volume). `PROCESSED_STORE_PATH` env var overrides the path.
- **`order-service/test/processedStore.test.js`** — new test: store pointed at a not-yet-existing parent directory persists correctly (the empty-volume case).
- **`.gitignore`** — ignore `order-service/data/`.
- **`docs/DEPLOYMENT.adoc`** — document the required volume in the container reference.

The compose-side change (named volume at `/app/order-service/data`) lands in the black-panther repo when this deploys.

## Test plan

1. `cd order-service && node --test` — all 23 tests pass, including the new missing-parent-directory test.
2. After merge + compose volume + rebuild on black-panther:
   - `docker compose exec robotechy ls /app/order-service/data` shows `.processed.json` once an order is processed;
   - logs show `[Store] Loaded N order(s)...` pointing at `/app/order-service/data/.processed.json`;
   - rebuild the container again and confirm the loaded count is **non-zero** (state survived the rebuild) and a previously processed order logs `Skipping duplicate order`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TkQZwPZF2imue3DBJ4X1Ex