### PR TITLE
feat: show site version in footer

### DIFF
--- a/docs/DEPLOYMENT.adoc
+++ b/docs/DEPLOYMENT.adoc
@@ -35,9 +35,14 @@ so nothing is exposed to the internet.
 
 == Releasing
 
+The footer shows the site version (from `package.json`'s `version` field,
+injected at build time — see `vite.config.ts`). Keep the tag and that field in
+lockstep: bump the version on `main` first, then tag that commit `v<version>`.
+
 [source,bash]
 ----
-# Tag the commit on main you want to ship, and push the tag.
+# 1. Bump the version in package.json (e.g. 1.2.3), commit to main.
+# 2. Tag the same commit on main and push the tag.
 git tag v1.2.3
 git push origin v1.2.3
 ----

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mkstack",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "npm i --silent && vite",

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -220,6 +220,16 @@ export function Footer({ selectedCollection, onCollectionClick }: FooterProps) {
               className="text-robotechy-green-dark hover:text-robotechy-orange transition-colors"
             >
               Vibed with MKStack
+            </a>{' '}
+            ·{' '}
+            <a
+              href={`https://github.com/RobotechyShop/robotechy-website/releases/tag/v${__APP_VERSION__}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              title="Deployed site version (release tag)"
+              className="hover:text-robotechy-green-dark transition-colors"
+            >
+              v{__APP_VERSION__}
             </a>
           </p>
         </div>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,4 @@
 /// <reference types="vite/client" />
+
+/** Site version injected at build time from package.json (vite.config.ts `define`). */
+declare const __APP_VERSION__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,23 @@
 import path from 'node:path';
+import { readFileSync } from 'node:fs';
 
 import react from '@vitejs/plugin-react-swc';
 import { defineConfig, configDefaults } from 'vitest/config';
+
+// The site version shown in the footer. Single source of truth is package.json's
+// `version` field — the release process bumps it and tags the same commit
+// `v<version>` (see docs/DEPLOYMENT.adoc), so what the footer shows always
+// matches the deployed tag.
+const pkg = JSON.parse(readFileSync(path.resolve(__dirname, 'package.json'), 'utf-8'));
 
 // https://vitejs.dev/config/
 export default defineConfig(() => ({
   server: {
     host: '::',
     port: 8080,
+  },
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
   },
   plugins: [react()],
   optimizeDeps: {


### PR DESCRIPTION
Fixes #44

## What

Adds the deployed site version to the footer credits line:

> Powered by Nostr · NIP-99 Marketplace (Gamma Markets) · Vibed with MKStack · **v1.0.0**

The version links to the matching GitHub release tag.

## How

- **`vite.config.ts`** — injects `package.json`'s `version` at build time via `define` (`__APP_VERSION__`); single source of truth, no runtime fetch.
- **`src/vite-env.d.ts`** — type declaration for the injected constant.
- **`src/components/Footer.tsx`** — appends `· v<version>` linking to `releases/tag/v<version>`.
- **`package.json`** — version bumped `0.0.0` → `1.0.0` as the starting point (site has been live for months).
- **`docs/DEPLOYMENT.adoc`** — release process: bump `package.json` on `main`, tag the same commit `v<version>`, so footer and tag stay in lockstep.

## Test plan

1. `npm run test` — full validation passes (TypeScript, ESLint, 167 unit tests, build).
2. Built bundle contains the version string: `grep -c "v1.0.0" dist/assets/index-*.js` → 1.
3. After deploy: load robotechy.com, scroll to the footer, confirm the credits line ends with `· v1.0.0` and the link points at the `v1.0.0` release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TkQZwPZF2imue3DBJ4X1Ex