### PR TITLE
fix: dedupe sent DMs against their optimistic bubble in the merge path

### DIFF
--- a/src/components/DMProvider.tsx
+++ b/src/components/DMProvider.tsx
@@ -5,7 +5,7 @@ import { useNostr } from '@nostrify/react';
 import { useAppContext } from '@/hooks/useAppContext';
 import { useNostrPublish } from '@/hooks/useNostrPublish';
 import { useToast } from '@/hooks/useToast';
-import { validateDMEvent } from '@/lib/dmUtils';
+import { validateDMEvent, mergeConversationMessages } from '@/lib/dmUtils';
 import {
   LOADING_PHASES,
   type LoadingPhase,
@@ -795,17 +795,12 @@ export function DMProvider({ children, config }: DMProviderProps) {
       newState.forEach((value, key) => {
         const existing = finalMap.get(key);
         if (existing) {
-          // For NIP-17 messages with originalGiftWrapId, dedupe by gift wrap ID
-          // For NIP-04 and cached NIP-17 messages, dedupe by message ID
-          const existingMessageIds = new Set(
-            existing.messages.map((msg) => msg.originalGiftWrapId || msg.id)
-          );
-          const newMessages = value.messages.filter(
-            (msg) => !existingMessageIds.has(msg.originalGiftWrapId || msg.id)
-          );
-
-          const mergedMessages = [...existing.messages, ...newMessages];
-          mergedMessages.sort((a, b) => a.created_at - b.created_at);
+          // Dedupe by gift wrap ID (NIP-17) / message ID (NIP-04, cache) AND
+          // replace a matching optimistic bubble instead of appending a second
+          // copy — otherwise a sent message renders twice whenever this poll
+          // path fetches the sender's own wrap before the live subscription
+          // does (the live path's addMessageToState already handles this).
+          const mergedMessages = mergeConversationMessages(existing.messages, value.messages);
 
           // Recalculate lastActivity and lastMessage after merging
           const lastMessage =

--- a/src/lib/dmUtils.merge.test.ts
+++ b/src/lib/dmUtils.merge.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { mergeConversationMessages, type MergeableMessage } from './dmUtils';
+
+/** Build a message with sensible defaults; override what the case needs. */
+function msg(overrides: Partial<MergeableMessage> & { id: string }): MergeableMessage {
+  return {
+    pubkey: 'sender',
+    created_at: 1_000,
+    decryptedContent: 'hello',
+    ...overrides,
+  };
+}
+
+describe('mergeConversationMessages', () => {
+  it('replaces a matching optimistic bubble instead of appending a duplicate (the poll-path dup)', () => {
+    // The production bug: "Do you get this?" rendered twice — the optimistic
+    // bubble (isSending, synthetic id) plus the relay-fetched wrap copy.
+    const optimistic = msg({
+      id: 'optimistic-123',
+      isSending: true,
+      decryptedContent: 'Do you get this?',
+      created_at: 1_000,
+      clientFirstSeen: 42,
+    });
+    const relayCopy = msg({
+      id: 'seal-id',
+      originalGiftWrapId: 'wrap-id',
+      decryptedContent: 'Do you get this?',
+      created_at: 1_005, // wraps land seconds later
+    });
+
+    const merged = mergeConversationMessages([optimistic], [relayCopy]);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].originalGiftWrapId).toBe('wrap-id'); // the confirmed copy…
+    expect(merged[0].isSending).toBeUndefined(); // …no longer "sending"
+    expect(merged[0].created_at).toBe(1_000); // keeps optimistic stamp (no jump)
+    expect(merged[0].clientFirstSeen).toBe(42); // keeps animation stamp
+  });
+
+  it('does not replace an optimistic bubble outside the 30s window', () => {
+    const optimistic = msg({ id: 'optimistic-1', isSending: true, created_at: 1_000 });
+    const late = msg({ id: 'real-1', originalGiftWrapId: 'wrap-1', created_at: 1_031 });
+
+    const merged = mergeConversationMessages([optimistic], [late]);
+    expect(merged).toHaveLength(2);
+  });
+
+  it('does not replace when content differs (two distinct messages sent quickly)', () => {
+    const optimistic = msg({ id: 'optimistic-1', isSending: true, decryptedContent: 'first' });
+    const other = msg({ id: 'real-1', originalGiftWrapId: 'wrap-1', decryptedContent: 'second' });
+
+    const merged = mergeConversationMessages([optimistic], [other]);
+    expect(merged).toHaveLength(2);
+  });
+
+  it('does not replace another author’s message even with identical content', () => {
+    const optimistic = msg({ id: 'optimistic-1', isSending: true, pubkey: 'me' });
+    const theirs = msg({ id: 'real-1', originalGiftWrapId: 'wrap-1', pubkey: 'them' });
+
+    const merged = mergeConversationMessages([optimistic], [theirs]);
+    expect(merged).toHaveLength(2);
+  });
+
+  it('dedupes a re-fetched NIP-17 wrap by originalGiftWrapId', () => {
+    const existing = msg({ id: 'seal-a', originalGiftWrapId: 'wrap-1' });
+    const refetched = msg({ id: 'seal-b', originalGiftWrapId: 'wrap-1' }); // same wrap, new decrypt
+
+    const merged = mergeConversationMessages([existing], [refetched]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].id).toBe('seal-a');
+  });
+
+  it('dedupes NIP-04 / cached messages by event id', () => {
+    const existing = msg({ id: 'event-1' });
+    const merged = mergeConversationMessages([existing], [msg({ id: 'event-1' })]);
+    expect(merged).toHaveLength(1);
+  });
+
+  it('dedupes duplicates within the incoming batch itself', () => {
+    const a = msg({ id: 'seal-a', originalGiftWrapId: 'wrap-1' });
+    const b = msg({ id: 'seal-b', originalGiftWrapId: 'wrap-1' });
+
+    const merged = mergeConversationMessages([], [a, b]);
+    expect(merged).toHaveLength(1);
+  });
+
+  it('replaces each optimistic bubble at most once (second identical incoming appends)', () => {
+    // Pathological but possible: two REAL sends with identical content in the
+    // same window. The first incoming copy consumes the optimistic bubble; the
+    // second must append, not silently vanish.
+    const optimistic = msg({ id: 'optimistic-1', isSending: true, created_at: 1_000 });
+    const copy1 = msg({ id: 's1', originalGiftWrapId: 'w1', created_at: 1_002 });
+    const copy2 = msg({ id: 's2', originalGiftWrapId: 'w2', created_at: 1_004 });
+
+    const merged = mergeConversationMessages([optimistic], [copy1, copy2]);
+    expect(merged).toHaveLength(2);
+    expect(merged.some((m) => m.isSending)).toBe(false);
+  });
+
+  it('appends and sorts by created_at when nothing matches', () => {
+    const merged = mergeConversationMessages(
+      [msg({ id: 'a', created_at: 3_000 })],
+      [msg({ id: 'b', created_at: 1_000 }), msg({ id: 'c', created_at: 2_000 })]
+    );
+    expect(merged.map((m) => m.id)).toEqual(['b', 'c', 'a']);
+  });
+});

--- a/src/lib/dmUtils.ts
+++ b/src/lib/dmUtils.ts
@@ -96,3 +96,80 @@ export function formatFullDateTime(timestamp: number): string {
     minute: '2-digit',
   });
 }
+
+/**
+ * Minimal structural shape needed to merge conversation messages — matches the
+ * fields of DMProvider's DecryptedMessage that dedup/replacement relies on.
+ */
+export interface MergeableMessage {
+  id: string;
+  pubkey: string;
+  created_at: number;
+  decryptedContent?: string;
+  /** True on the local optimistic bubble added when the user hits send. */
+  isSending?: boolean;
+  /** NIP-17: the outer gift wrap id (stable dedup key across re-fetches). */
+  originalGiftWrapId?: string;
+  /** Client-side arrival stamp used for entry animations. */
+  clientFirstSeen?: number;
+}
+
+/**
+ * How far apart (seconds) an optimistic bubble and its confirmed relay copy may
+ * be stamped and still be treated as the same message. Mirrors the live
+ * subscription path's window in DMProvider.addMessageToState.
+ */
+const OPTIMISTIC_MATCH_WINDOW_SECONDS = 30;
+
+/**
+ * Merge incoming (relay-fetched) messages into a conversation's existing list.
+ *
+ * - Dedupes by `originalGiftWrapId || id` (NIP-17 wraps re-fetched across polls
+ *   keep a stable wrap id; NIP-04 and cached messages use the event id).
+ * - Replaces a matching optimistic bubble (`isSending` + same author + same
+ *   decrypted content within a small time window) instead of appending a
+ *   second copy. Without this, a sent message shows TWICE whenever the poll
+ *   path fetches the sender's own wrap before the live subscription does —
+ *   the optimistic bubble (spinner forever) plus the confirmed copy. The
+ *   replacement keeps the optimistic `created_at`/`clientFirstSeen` so the
+ *   bubble doesn't jump or re-animate (mirrors addMessageToState).
+ *
+ * Returns a new array sorted by `created_at` ascending.
+ */
+export function mergeConversationMessages<T extends MergeableMessage>(
+  existing: T[],
+  incoming: T[]
+): T[] {
+  const merged = [...existing];
+  const seenIds = new Set(merged.map((msg) => msg.originalGiftWrapId || msg.id));
+
+  for (const message of incoming) {
+    const messageId = message.originalGiftWrapId || message.id;
+    if (seenIds.has(messageId)) {
+      continue;
+    }
+    seenIds.add(messageId);
+
+    const optimisticIndex = merged.findIndex(
+      (msg) =>
+        msg.isSending &&
+        msg.pubkey === message.pubkey &&
+        msg.decryptedContent === message.decryptedContent &&
+        Math.abs(msg.created_at - message.created_at) <= OPTIMISTIC_MATCH_WINDOW_SECONDS
+    );
+
+    if (optimisticIndex !== -1) {
+      const optimistic = merged[optimisticIndex];
+      merged[optimisticIndex] = {
+        ...message,
+        created_at: optimistic.created_at,
+        clientFirstSeen: optimistic.clientFirstSeen,
+      };
+    } else {
+      merged.push(message);
+    }
+  }
+
+  merged.sort((a, b) => a.created_at - b.created_at);
+  return merged;
+}

--- a/src/lib/dmUtils.ts
+++ b/src/lib/dmUtils.ts
@@ -143,6 +143,16 @@ export function mergeConversationMessages<T extends MergeableMessage>(
   const merged = [...existing];
   const seenIds = new Set(merged.map((msg) => msg.originalGiftWrapId || msg.id));
 
+  // Optimistic bubbles can only pre-exist in `existing` (relay-fetched copies
+  // never carry isSending), and there are at most a handful at once. Index them
+  // up front and search only that set — a full findIndex per incoming message
+  // would make large catch-up merges (thousands of messages, no bubbles at all)
+  // O(n²) for nothing.
+  let optimisticIndices = merged.reduce<number[]>((indices, msg, index) => {
+    if (msg.isSending) indices.push(index);
+    return indices;
+  }, []);
+
   for (const message of incoming) {
     const messageId = message.originalGiftWrapId || message.id;
     if (seenIds.has(messageId)) {
@@ -150,21 +160,27 @@ export function mergeConversationMessages<T extends MergeableMessage>(
     }
     seenIds.add(messageId);
 
-    const optimisticIndex = merged.findIndex(
-      (msg) =>
-        msg.isSending &&
-        msg.pubkey === message.pubkey &&
-        msg.decryptedContent === message.decryptedContent &&
-        Math.abs(msg.created_at - message.created_at) <= OPTIMISTIC_MATCH_WINDOW_SECONDS
-    );
+    const optimisticIndex =
+      optimisticIndices.length > 0
+        ? optimisticIndices.find((index) => {
+            const msg = merged[index];
+            return (
+              msg.pubkey === message.pubkey &&
+              msg.decryptedContent === message.decryptedContent &&
+              Math.abs(msg.created_at - message.created_at) <= OPTIMISTIC_MATCH_WINDOW_SECONDS
+            );
+          })
+        : undefined;
 
-    if (optimisticIndex !== -1) {
+    if (optimisticIndex !== undefined) {
       const optimistic = merged[optimisticIndex];
       merged[optimisticIndex] = {
         ...message,
         created_at: optimistic.created_at,
         clientFirstSeen: optimistic.clientFirstSeen,
       };
+      // Consumed — a bubble is replaced at most once.
+      optimisticIndices = optimisticIndices.filter((index) => index !== optimisticIndex);
     } else {
       merged.push(message);
     }


### PR DESCRIPTION
Fixes #49

## What

A sent NIP-17 DM could appear **twice** in the Messages drawer — the optimistic bubble (spinner forever) plus the confirmed relay copy, same timestamp. Observed in production 2026-07-02 ("Do you get this?" at 16:27, duplicated).

## Root cause

Two paths ingest the sender's own gift-wrap copy back from relays:

| Path | Handler | Optimistic replacement? |
|---|---|---|
| Live subscription | `addMessageToState` | ✅ matches `isSending` + author + content ±30s and swaps |
| Periodic poll / catch-up | `mergeMessagesIntoState` | ❌ deduped only by `originalGiftWrapId \|\| id` |

The optimistic bubble has a synthetic `optimistic-…` id and no wrap id, so the poll path could never match it — whenever the poll fetched the wrap before the live sub, both bubbles stayed.

## Fix

- New pure helper `mergeConversationMessages` in `src/lib/dmUtils.ts`: dedupes by wrap/event id **and** replaces a matching optimistic bubble (same predicate as the live path), preserving the optimistic `created_at`/`clientFirstSeen` so the bubble doesn't jump or re-animate. Each optimistic bubble is consumed at most once, so two genuinely identical sends don't collapse into one.
- `mergeMessagesIntoState` now delegates to it.

## Test plan

1. `npx vitest run src/lib/dmUtils.merge.test.ts` — 9 new tests: the production duplicate scenario, window/content/author boundaries, wrap-id + event-id dedup, in-batch dedup, at-most-once replacement, sort order.
2. Full suite: 176 tests / 19 files pass; typecheck, lint, build clean.
3. After deploy: send a DM from the Messages drawer, leave the drawer open through a poll cycle (~30s) — exactly one bubble should remain, with no stuck spinner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TkQZwPZF2imue3DBJ4X1Ex