### PR TITLE
docs: fix README order-flow Mermaid diagram parse error

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ sequenceDiagram
     Note right of M: One invoice, delivered two ways —<br/>same BOLT11, same ["order", id] tag
     M->>B: Payment request · gift wrap 1059 ⟶ inner kind 16 type 2<br/>(rich "order card" — BOLT11 invoice)
     M->>B: Invoice note · gift wrap 1059 ⟶ inner kind 14<br/>(SAME BOLT11 — fallback for generic NIP-17 clients)
-    Note over B: Gamma-aware client (Lightning Piggy) shows the<br/>kind 16 card and suppresses the kind 14 duplicate;<br/>a generic client (0xchat · Amethyst) shows the kind 14 note
+    Note over B: Gamma-aware client (Lightning Piggy) shows the<br/>kind 16 card and suppresses the kind 14 duplicate —<br/>a generic client (0xchat · Amethyst) shows the kind 14 note
     B->>L: Pay invoice ⚡
     B->>M: Receipt · gift wrap 1059 ⟶ inner kind 17<br/>(BOLT11 + preimage proof)
     M->>B: Confirmation · gift wrap 1059 ⟶ inner kind 16 type 3<br/>(status: confirmed)


### PR DESCRIPTION
## What

The order-flow sequence diagram on the repo front page showed a Mermaid render error instead of the diagram.

**Root cause:** a semicolon inside a `Note` line (`…suppresses the kind 14 duplicate;<br/>a generic client…`). In Mermaid's sequence-diagram grammar `;` terminates the statement, so the rest of the note parsed as a new, invalid statement:

```
Parse error on line 17:
...nd 14 duplicate;<br/>a generic client (0
-----------------------^
```

**Fix:** replace the semicolon with an em dash — same reading, no grammar collision.

## Test plan

N/A — docs-only. Verified with Mermaid v11's own parser (`mermaid.parse`): errors exactly as GitHub does before the fix, `PARSE OK` after. Visual check on the GitHub repo page after merge confirms the diagram renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TkQZwPZF2imue3DBJ4X1Ex