### PR TITLE
chore: enable TypeScript strict mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,7 @@ The `vite.config.ts` includes `optimizeDeps.include: ['style-to-js']` to handle 
 - Read `AGENTS.md` for complete Nostr protocol implementation patterns and design standards
 - Never modify `App.tsx` unless adding new providers
 - Dev server binds to `::` (IPv6) on port 8080
-- Uses TypeScript with `strictNullChecks` but not `strict` mode
+- Uses TypeScript in full `strict` mode
 
 ## User Context
 

--- a/src/hooks/useNostrPublish.ts
+++ b/src/hooks/useNostrPublish.ts
@@ -5,12 +5,19 @@ import { useCurrentUser } from './useCurrentUser';
 
 import type { NostrEvent } from '@nostrify/nostrify';
 
-export function useNostrPublish(): UseMutationResult<NostrEvent> {
+/** Unsigned event template accepted by the publish mutation. `tags` and
+ *  `created_at` are optional — the mutation defaults them to [] / "now". */
+type EventTemplate = Omit<NostrEvent, 'id' | 'pubkey' | 'sig' | 'created_at' | 'tags'> & {
+  tags?: string[][];
+  created_at?: number;
+};
+
+export function useNostrPublish(): UseMutationResult<NostrEvent, Error, EventTemplate> {
   const { nostr } = useNostr();
   const { user } = useCurrentUser();
 
   return useMutation({
-    mutationFn: async (t: Omit<NostrEvent, 'id' | 'pubkey' | 'sig'>) => {
+    mutationFn: async (t: EventTemplate) => {
       if (user) {
         const tags = t.tags ?? [];
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,11 +15,9 @@
     "jsx": "react-jsx",
 
     /* Linting */
-    "strict": false,
-    "strictNullChecks": true,
+    "strict": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
-    "noImplicitAny": false,
     "noFallthroughCasesInSwitch": false,
 
     "baseUrl": ".",


### PR DESCRIPTION
## What

Flips `tsconfig.json` to full `"strict": true` (dropping the now-redundant `strictNullChecks` / `noImplicitAny` overrides), matching Thyme and ZapDesk.

Because `strictNullChecks` — the heavy 90% of strict mode — was already enabled, the whole 25k-LOC codebase needed exactly **one fix**: `useNostrPublish` declared its return as `UseMutationResult<NostrEvent>`, which erased the mutation's variables generic and only coerced under loose checking. It now declares the full generics with an accurate `EventTemplate` input type (`tags`/`created_at` optional, matching the mutation's runtime defaults — two callers legitimately omit them).

Also updates the stale CLAUDE.md note ("strictNullChecks but not strict mode").

## Test plan

1. `npx tsc --noEmit` under strict: **0 errors**.
2. `npm run test` — full validation passes (TypeScript, ESLint, 167 unit tests, build).
3. No runtime behaviour change — types only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TkQZwPZF2imue3DBJ4X1Ex