### PR TITLE
ci: add Dependabot version-update config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+# Dependabot version updates. Security updates are enabled separately in the
+# repo settings (Dependabot security updates) and fire regardless of this file.
+version: 2
+updates:
+  # Frontend (Vite/React app)
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    # One PR per week for all minor+patch bumps keeps the noise down; majors
+    # stay separate so breaking upgrades get individual review.
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  # Order service (Node backend)
+  - package-ecosystem: npm
+    directory: /order-service
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  # GitHub Actions workflows
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 2


### PR DESCRIPTION
## What

Turns on the remaining Dependabot pieces (alerts were already enabled; **security auto-PRs enabled in settings** alongside this PR):

- **npm / root** — weekly, minor+patch grouped into a single PR (majors stay separate for individual review), max 5 open PRs
- **npm / order-service** — same policy, max 3
- **github-actions** — weekly workflow-action bumps, max 2

Grouping keeps the Monday noise to ~1–2 PRs instead of a dozen; CI (types, lint, 190+ tests, build) gates every bump like any other PR.

## Test plan

N/A — CI/config only. Dependabot validates the config on merge (Insights → Dependency graph → Dependabot shows the three update jobs); first scheduled run next Monday, or trigger manually from that tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TkQZwPZF2imue3DBJ4X1Ex