### PR TITLE
fix: classify relay 'publish timed out' as ignorable noise

### DIFF
--- a/order-service/lib/relayErrors.js
+++ b/order-service/lib/relayErrors.js
@@ -27,6 +27,14 @@ const RELAY_NOISE = [
   // specific to ws's upgrade path — the LNURL/Lightning fetch path can never
   // produce it — so matching it cannot swallow a real payment error.
   'unexpected server response',
+  // nostr-tools' relay publish timeout ("publish timed out"), raised on an
+  // internal promise nobody awaits when a slow relay never ACKs the event.
+  // The publish paths already handle per-relay failures via allSettled — a
+  // single slow relay must not kill the service (crashed production on
+  // 2026-07-02 and restarted the container via the supervised entrypoint).
+  // Phrase is specific to the relay publish path, so it cannot swallow a
+  // Lightning/LNURL HTTP timeout.
+  'publish timed out',
   // Specific connection/socket phrases only — a bare 'connection' or 'timeout'
   // would swallow unrelated failures (e.g. a Lightning/LNURL HTTP timeout, which
   // is a real error). Relay/socket timeouts reaching this handler always carry a

--- a/order-service/test/relayErrors.test.js
+++ b/order-service/test/relayErrors.test.js
@@ -18,6 +18,15 @@ test('ignores the ws handshake rejection ("Unexpected server response: 403") tha
   assert.equal(isIgnorableRelayError(new Error('Unexpected server response: 502')), true);
 });
 
+test('ignores the relay publish timeout ("publish timed out") that crashed the service in production', () => {
+  // nostr-tools raises this on an internal promise when a slow relay never
+  // ACKs a published event — relay noise, not a genuine bug (2026-07-02).
+  assert.equal(isIgnorableRelayError(new Error('publish timed out')), true);
+  // But generic/HTTP timeouts must STAY fatal (LNURL fetch timeouts are real).
+  assert.equal(isIgnorableRelayError(new Error('Request Timeout')), false);
+  assert.equal(isIgnorableRelayError(new Error('fetch timeout')), false);
+});
+
 test('ignores known transient relay/network errors (case-insensitive)', () => {
   for (const m of [
     'restricted: Pay on https://nostr.land for access.',


### PR DESCRIPTION
Fixes #60

## What

Tonight's service-crash notification (~19:01 UTC): the order service exited on `[Fatal] Unhandled rejection: Error: publish timed out`, and the supervised entrypoint restarted the container as designed (visible restart, dedup store intact — the notification is the system working; before #40 this was a silent zombie).

Root cause is a classifier gap, same family as the 403 handshake crash (#41): nostr-tools raises `publish timed out` on an internal unawaited promise when a slow relay never ACKs an event. The publish paths already tolerate per-relay failures via `Promise.allSettled`, so this is relay noise — but the phrase wasn't in `RELAY_NOISE` because bare "timeout" is deliberately excluded (a Lightning/LNURL HTTP timeout is a *real* error that must stay fatal).

The exact phrase `publish timed out` is specific to the relay publish path, so classifying it cannot swallow a payment error.

## Test plan

1. `cd order-service && node --test` — **24/24 pass**, including the new regression test: `publish timed out` → ignorable; `Request Timeout` / `fetch timeout` → still fatal.
2. After merge + deploy: a slow relay logs `[Nostr] Ignoring relay rejection: publish timed out` and the service keeps polling instead of restarting the container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TkQZwPZF2imue3DBJ4X1Ex