### PR TITLE
fix: don't flash a generated pseudonym while the story profile loads

### DIFF
--- a/src/pages/Story.test.tsx
+++ b/src/pages/Story.test.tsx
@@ -57,6 +57,31 @@ describe('Story page', () => {
     >);
   });
 
+  it('shows a name skeleton (never a generated pseudonym) while the profile loads', () => {
+    // Regression: before the fix, the hero fell back to genUserName() while the
+    // kind-0 profile was still loading, flashing a pseudonym like "Brave Falcon"
+    // that then flipped to the real shop name.
+    mockedUseAuthor.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as unknown as ReturnType<typeof useAuthor>);
+    mockedUseStoryNotes.mockReturnValue(storyResult({ isLoading: true }));
+    renderStory();
+    expect(screen.getByTestId('story-name-loading')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(/^$/);
+  });
+
+  it('falls back to a generated name only after the profile lookup settles empty', () => {
+    mockedUseAuthor.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    } as unknown as ReturnType<typeof useAuthor>);
+    mockedUseStoryNotes.mockReturnValue(storyResult({ isLoading: true }));
+    renderStory();
+    expect(screen.queryByTestId('story-name-loading')).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1 }).textContent).not.toHaveLength(0);
+  });
+
   it('renders the shop profile hero (name + about + Our Story label)', () => {
     mockedUseStoryNotes.mockReturnValue(storyResult({ isLoading: true }));
     renderStory();

--- a/src/pages/Story.tsx
+++ b/src/pages/Story.tsx
@@ -36,7 +36,14 @@ const Story = () => {
   const shopEvent = author.data?.event;
 
   const metadata = author.data?.metadata;
-  const name = metadata?.display_name || metadata?.name || genUserName(MERCHANT_PUBKEY);
+  // While the kind-0 profile is still loading, don't fall back to a generated
+  // pseudonym — it briefly flashes (e.g. "Brave Falcon") and then flips to the
+  // real shop name. Leave the name empty (the hero shows a skeleton) and only
+  // generate a placeholder once the lookup has settled with no metadata.
+  const name =
+    metadata?.display_name ||
+    metadata?.name ||
+    (author.isLoading ? '' : genUserName(MERCHANT_PUBKEY));
   const bio =
     metadata?.about ||
     'The story of Robotechy — 3D printing for the Bitcoin community, one print at a time.';
@@ -66,7 +73,7 @@ const Story = () => {
           {metadata?.banner && (
             <img
               src={metadata.banner}
-              alt={`${name} banner`}
+              alt={`${name || 'Robotechy'} banner`}
               decoding="async"
               referrerPolicy="no-referrer"
               className="absolute inset-0 h-full w-full object-cover"
@@ -78,7 +85,7 @@ const Story = () => {
           {/* Avatar overlaps the banner, profile-style. */}
           <div className="-mt-12 sm:-mt-14">
             <Avatar className="h-24 w-24 border-4 border-white shadow-md dark:border-neutral-950 sm:h-28 sm:w-28">
-              <AvatarImage src={metadata?.picture} alt={name} />
+              <AvatarImage src={metadata?.picture} alt={name || 'Robotechy'} />
               <AvatarFallback className="text-3xl">
                 {(name.trim().charAt(0) || 'R').toUpperCase()}
               </AvatarFallback>
@@ -87,7 +94,7 @@ const Story = () => {
 
           <div className="mt-3">
             <h1 className="text-2xl font-bold text-slate-900 dark:text-white sm:text-3xl">
-              {name}
+              {name || <Skeleton className="h-8 w-56" data-testid="story-name-loading" />}
             </h1>
             <p className="mt-2 max-w-2xl whitespace-pre-line text-sm leading-relaxed text-sage-600 dark:text-sage-400">
               {bio}


### PR DESCRIPTION
Fixes #67

## What

Opening `/story` briefly showed a generated pseudonym ("Brave Falcon") as the shop name, flipping to "RobotechyShop" once the kind-0 profile arrived from relays.

The hero name was `display_name || name || genUserName(pubkey)` — the pseudonym fallback (meant for accounts with *no* profile) fired during the loading window too. Now it's gated on `author.isLoading`: the heading renders a skeleton while the profile loads, and a generated name appears only when the lookup settles genuinely empty. Banner/avatar `alt` text falls back to "Robotechy" during the window.

## Test plan

1. `npx vitest run src/pages/Story.test.tsx` — 8/8, including two new regression tests: loading → skeleton + empty heading (no pseudonym); settled-empty → generated fallback still works.
2. Full suite: 193 tests pass; typecheck/lint/build clean.
3. After deploy: hard-refresh robotechy.com/story — the name area shows a brief skeleton pulse, then "RobotechyShop"; no "Brave Falcon" at any point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TkQZwPZF2imue3DBJ4X1Ex