### PR TITLE
feat: share the storefront link alongside njump

### DIFF
--- a/src/components/ShareProductButton.tsx
+++ b/src/components/ShareProductButton.tsx
@@ -30,6 +30,7 @@ import {
   buildProductNaddr,
   buildShareNoteContent,
   buildShareNoteEvent,
+  buildStoreUrl,
   formatPriceLabel,
 } from '@/lib/shareProduct';
 
@@ -92,27 +93,30 @@ export function ShareProductButton({
     [config.relayMetadata.relays]
   );
 
-  // The product's portable pointer and the human-facing njump link. Memoised so
-  // every menu action (copy / native share / Nostr note) uses the same URL.
-  const { naddr, njumpUrl, defaultNote } = useMemo(() => {
+  // The product's portable pointer plus its two human-facing links: the
+  // storefront page (primary — what copy/native share hand out) and the njump
+  // fallback. Memoised so every menu action uses the same URLs.
+  const { naddr, storeUrl, defaultNote } = useMemo(() => {
     const naddr = buildProductNaddr(merchantPubkey, product.id, relayHints);
+    const storeUrl = buildStoreUrl(naddr);
     const njumpUrl = buildNjumpUrl(naddr);
     const defaultNote = buildShareNoteContent({
       title: product.title,
       priceLabel: formatPriceLabel(product.price),
+      storeUrl,
       njumpUrl,
     });
-    return { naddr, njumpUrl, defaultNote };
+    return { naddr, storeUrl, defaultNote };
   }, [merchantPubkey, product.id, product.title, product.price, relayHints]);
 
   const copyLink = async () => {
     try {
-      await navigator.clipboard.writeText(njumpUrl);
+      await navigator.clipboard.writeText(storeUrl);
       toast({ title: 'Link copied', description: 'Product link copied to clipboard.' });
     } catch {
       toast({
         title: 'Could not copy',
-        description: njumpUrl,
+        description: storeUrl,
         variant: 'destructive',
       });
     }
@@ -127,7 +131,7 @@ export function ShareProductButton({
       await navigator.share({
         title: product.title,
         text: product.summary || product.title,
-        url: njumpUrl,
+        url: storeUrl,
       });
     } catch (error) {
       // AbortError = the user dismissed the share sheet; not worth a toast.
@@ -228,8 +232,8 @@ export function ShareProductButton({
               Share to Nostr
             </DialogTitle>
             <DialogDescription>
-              Post a note about this product to your Nostr feed. The product is linked so your
-              followers can open it on njump.
+              Post a note about this product to your Nostr feed. The note links to the product on
+              the Robotechy store and njump so your followers can open it either way.
             </DialogDescription>
           </DialogHeader>
 
@@ -250,7 +254,7 @@ export function ShareProductButton({
             />
           </div>
 
-          <p className="text-xs text-sage-500 dark:text-sage-400 break-all">{njumpUrl}</p>
+          <p className="text-xs text-sage-500 dark:text-sage-400 break-all">{storeUrl}</p>
 
           <DialogFooter className="gap-2 sm:gap-2">
             <Button variant="outline" onClick={() => void copyLink()} type="button">

--- a/src/lib/shareProduct.test.ts
+++ b/src/lib/shareProduct.test.ts
@@ -3,9 +3,11 @@ import { nip19 } from 'nostr-tools';
 
 import {
   PRODUCT_KIND,
+  STORE_BASE_URL,
   buildProductAddress,
   buildProductNaddr,
   buildNjumpUrl,
+  buildStoreUrl,
   formatPriceLabel,
   buildShareNoteContent,
   buildShareNoteEvent,
@@ -47,6 +49,13 @@ describe('buildNjumpUrl', () => {
   });
 });
 
+describe('buildStoreUrl', () => {
+  it('prefixes the naddr with the canonical storefront origin', () => {
+    expect(buildStoreUrl('naddr1abc')).toBe(`${STORE_BASE_URL}/naddr1abc`);
+    expect(buildStoreUrl('naddr1abc')).toBe('https://www.robotechy.com/naddr1abc');
+  });
+});
+
 describe('formatPriceLabel', () => {
   it('renders whole sats with thousands separators', () => {
     expect(formatPriceLabel({ amount: '21000', currency: 'sats' })).toBe('21,000 sats');
@@ -62,19 +71,24 @@ describe('formatPriceLabel', () => {
 });
 
 describe('buildShareNoteContent', () => {
-  it('composes the Robotechy share body', () => {
+  it('composes the Robotechy share body with the store link then njump', () => {
     expect(
       buildShareNoteContent({
         title: 'Widget 3000',
         priceLabel: '21,000 sats',
+        storeUrl: 'https://www.robotechy.com/naddr1abc',
         njumpUrl: 'https://njump.me/naddr1abc',
       })
-    ).toBe('Check out Widget 3000 on Robotechy ⚡ 21,000 sats\n\nhttps://njump.me/naddr1abc');
+    ).toBe(
+      'Check out Widget 3000 on Robotechy ⚡ 21,000 sats\n\n' +
+        'https://www.robotechy.com/naddr1abc\n' +
+        'https://njump.me/naddr1abc'
+    );
   });
 });
 
 describe('buildShareNoteEvent', () => {
-  it('builds a kind-1 note with a, r and image tags', () => {
+  it('builds a kind-1 note with a, both r links and image tags', () => {
     const event = buildShareNoteEvent({
       pubkey: PUBKEY,
       identifier: D,
@@ -86,10 +100,14 @@ describe('buildShareNoteEvent', () => {
     expect(event.kind).toBe(1);
 
     const naddr = buildProductNaddr(PUBKEY, D);
+    const storeUrl = buildStoreUrl(naddr);
     const njumpUrl = buildNjumpUrl(naddr);
-    expect(event.content).toBe(`Check out Widget 3000 on Robotechy ⚡ 21,000 sats\n\n${njumpUrl}`);
+    expect(event.content).toBe(
+      `Check out Widget 3000 on Robotechy ⚡ 21,000 sats\n\n${storeUrl}\n${njumpUrl}`
+    );
 
     expect(event.tags).toContainEqual(['a', `30402:${PUBKEY}:${D}`]);
+    expect(event.tags).toContainEqual(['r', storeUrl]);
     expect(event.tags).toContainEqual(['r', njumpUrl]);
     expect(event.tags).toContainEqual(['image', 'https://img.example/widget.png']);
   });

--- a/src/lib/shareProduct.test.ts
+++ b/src/lib/shareProduct.test.ts
@@ -51,8 +51,10 @@ describe('buildNjumpUrl', () => {
 
 describe('buildStoreUrl', () => {
   it('prefixes the naddr with the canonical storefront origin', () => {
+    // Pin the production origin once so a stray edit to the constant is caught,
+    // then assert the helper composes the URL from it.
+    expect(STORE_BASE_URL).toBe('https://www.robotechy.com');
     expect(buildStoreUrl('naddr1abc')).toBe(`${STORE_BASE_URL}/naddr1abc`);
-    expect(buildStoreUrl('naddr1abc')).toBe('https://www.robotechy.com/naddr1abc');
   });
 });
 

--- a/src/lib/shareProduct.ts
+++ b/src/lib/shareProduct.ts
@@ -13,6 +13,13 @@ import { formatPriceFromTag, type ProductData } from '@/lib/productUtils';
 export const PRODUCT_KIND = 30402;
 
 /**
+ * Canonical, production storefront origin. Shared links must point here (not
+ * `window.location.origin`, which is `localhost` in dev / a test host) so the
+ * URL a shopper copies or posts always opens the real, branded shop.
+ */
+export const STORE_BASE_URL = 'https://www.robotechy.com';
+
+/**
  * The addressable-event coordinate for a product, used as the value of an `a`
  * tag (NIP-01): `30402:<merchant-pubkey>:<d-identifier>`.
  */
@@ -39,6 +46,15 @@ export function buildNjumpUrl(naddr: string): string {
 }
 
 /**
+ * The product's canonical page on the Robotechy storefront itself. The `/:nip19`
+ * route resolves the naddr to the product detail page, so this is the branded,
+ * works-for-everyone link (with a Buy button) — the primary thing we share.
+ */
+export function buildStoreUrl(naddr: string): string {
+  return `${STORE_BASE_URL}/${naddr}`;
+}
+
+/**
  * Format a product price for the share note. Sats are shown as whole numbers
  * (no fractional sats); every other currency falls back to the storefront's
  * shared price formatter so the wording matches what the card/detail show.
@@ -55,19 +71,23 @@ export function formatPriceLabel(price: ProductData['price']): string {
 export interface ShareNoteContentInput {
   title: string;
   priceLabel: string;
+  storeUrl: string;
   njumpUrl: string;
 }
 
 /**
- * The human-readable body of the kind-1 note, e.g.
- * `Check out Widget on Robotechy ⚡ 21,000 sats\n\nhttps://njump.me/naddr1…`.
+ * The human-readable body of the kind-1 note. Carries both links — the
+ * storefront page first (the branded, buy-here destination) and the njump
+ * fallback second, so it renders for Nostr-native and web readers alike:
+ * `Check out Widget on Robotechy ⚡ 21,000 sats\n\n<storeUrl>\n<njumpUrl>`.
  */
 export function buildShareNoteContent({
   title,
   priceLabel,
+  storeUrl,
   njumpUrl,
 }: ShareNoteContentInput): string {
-  return `Check out ${title} on Robotechy ⚡ ${priceLabel}\n\n${njumpUrl}`;
+  return `Check out ${title} on Robotechy ⚡ ${priceLabel}\n\n${storeUrl}\n${njumpUrl}`;
 }
 
 export interface ShareNoteEventInput {
@@ -89,23 +109,27 @@ export interface ShareNoteEventTemplate {
 
 /**
  * Build the kind-1 note template that references a product: the body links to
- * the product via njump, an `a` tag points at the addressable product event, an
- * `r` tag carries the njump URL, and (when present) an `image` tag carries the
- * product photo. This is a fresh note — it never edits an existing event.
+ * the product on both the storefront and njump, an `a` tag points at the
+ * addressable product event, `r` tags carry the store and njump URLs, and (when
+ * present) an `image` tag carries the product photo. This is a fresh note — it
+ * never edits an existing event.
  */
 export function buildShareNoteEvent(input: ShareNoteEventInput): ShareNoteEventTemplate {
   const naddr = buildProductNaddr(input.pubkey, input.identifier, input.relays);
+  const storeUrl = buildStoreUrl(naddr);
   const njumpUrl = buildNjumpUrl(naddr);
   const content =
     input.content ??
     buildShareNoteContent({
       title: input.title,
       priceLabel: formatPriceLabel(input.price),
+      storeUrl,
       njumpUrl,
     });
 
   const tags: string[][] = [
     ['a', buildProductAddress(input.pubkey, input.identifier)],
+    ['r', storeUrl],
     ['r', njumpUrl],
   ];
   if (input.imageUrl) {


### PR DESCRIPTION
## Summary

The product **Share** button previously handed out only the `njump.me` URL, sending people to a generic Nostr viewer instead of the branded shop with a Buy button. This adds the storefront link as the primary shareable URL.

- **Copy link** and native **Share…** now give the canonical storefront URL: `https://www.robotechy.com/<naddr>` — works for everyone, Nostr or not.
- The published **kind-1 note** carries both links (store first, njump second) and an `r` tag for each, so it renders for web and Nostr-native readers alike.
- The share composer's dialog caption/description updated to match.

New `STORE_BASE_URL` constant + `buildStoreUrl()` helper in `src/lib/shareProduct.ts`; the URL is hardcoded to the production origin (not `window.location.origin`, which would leak `localhost` into shared links).

Fixes #75

### Before → After (Nostr note body)

```
Before:
  Check out Lightning Piggy on Robotechy ⚡ 21,000 sats
  https://njump.me/naddr1…

After:
  Check out Lightning Piggy on Robotechy ⚡ 21,000 sats
  https://www.robotechy.com/naddr1…
  https://njump.me/naddr1…
```

## Test plan

1. CI: TypeScript, ESLint, Prettier, unit tests (`shareProduct` now has 12 cases incl. `buildStoreUrl` + both-link note body), production build.
2. On a product card/detail, open **Share → Copy link** → clipboard holds `https://www.robotechy.com/<naddr>`; opening it loads the product page.
3. **Share…** (native, mobile) → the shared URL is the storefront link.
4. **Share to Nostr** → composer shows the store URL; the posted note body contains both the store link and the njump link, and the event has an `r` tag for each.