### PR TITLE
fix: guard useExchangeRate setState against unmount

### DIFF
--- a/src/hooks/useExchangeRate.ts
+++ b/src/hooks/useExchangeRate.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { getExchangeRates } from '@/lib/exchangeRate';
 
 interface UseExchangeRateReturn {
@@ -23,28 +23,39 @@ export function useExchangeRate(): UseExchangeRateReturn {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  // Tracks whether the component is still mounted, so the async rate fetch never
+  // calls setState after unmount — which otherwise surfaces as an unhandled
+  // "window is not defined" from React's scheduler once a test env tears down.
+  const mountedRef = useRef(false);
+
   const fetchRates = useCallback(async () => {
     setIsLoading(true);
     setError(null);
 
     try {
       const rates = await getExchangeRates();
+      if (!mountedRef.current) return;
       // sats per £1 = 100,000,000 / BTC price in GBP
       setSatsPerGbp(Math.round(SATS_PER_BTC / rates.btcToGbp));
       setSatsPerUsd(Math.round(SATS_PER_BTC / rates.btcToUsd));
     } catch (err) {
+      if (!mountedRef.current) return;
       const message = err instanceof Error ? err.message : 'Failed to fetch rates';
       setError(message);
       // Use fallback rates
       setSatsPerGbp(Math.round(SATS_PER_BTC / FALLBACK_BTC_GBP));
       setSatsPerUsd(Math.round(SATS_PER_BTC / FALLBACK_BTC_USD));
     } finally {
-      setIsLoading(false);
+      if (mountedRef.current) setIsLoading(false);
     }
   }, []);
 
   useEffect(() => {
+    mountedRef.current = true;
     fetchRates();
+    return () => {
+      mountedRef.current = false;
+    };
   }, [fetchRates]);
 
   const convertToSats = useCallback(


### PR DESCRIPTION
## Summary

Fixes the intermittently-failing **Coverage gate**. `useExchangeRate` fired `getExchangeRates()` on mount and called `setState` when it resolved — even if the component had already unmounted. Under the slower coverage run, that post-unmount `setState` reached react-dom's scheduler after the jsdom env was torn down, throwing an unhandled `ReferenceError: window is not defined` and failing the job (all tests still passed; coverage was ~40%, well above the floor).

Now the hook tracks mount state in a ref and skips the post-`await` `setState` after unmount. **No behaviour change for mounted components.**

Fixes #79

## Test plan

1. CI: TypeScript, ESLint, Prettier, unit tests, production build.
2. **Coverage gate**: the run's log no longer contains `ReferenceError: window is not defined` / "Vitest caught N unhandled errors", and the gate passes on the first attempt (previously needed manual re-runs on #76 and #78).
3. Existing exchange-rate-dependent UI (prices in sats/fiat) is unchanged — mounted components still fetch and display rates exactly as before.