### PR TITLE
fix: show product photo in shares; fix og:image host

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,30 +1,48 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Robotechy | 3D Printing Bitcoin Store | Bitcoin Seed Signer Cases</title>
-    <meta name="description" content="3D printing store specializing in Bitcoin Seed Signer cases and accessories. We accept Bitcoin payments.">
+    <meta
+      name="description"
+      content="3D printing store specializing in Bitcoin Seed Signer cases and accessories. We accept Bitcoin payments."
+    />
     <!-- Store-level Open Graph tags. These are STATIC so social crawlers (which
          do not run JS) see them when the storefront link is shared. Per-product
          previews are injected at runtime in ProductDetail and are not visible to
          crawlers — see src/lib/productMeta.ts. og:image must be an absolute URL. -->
-    <meta property="og:type" content="website">
-    <meta property="og:site_name" content="Robotechy">
-    <meta property="og:title" content="Robotechy | 3D Printing Bitcoin Store">
-    <meta property="og:description" content="3D printing store specializing in Bitcoin Seed Signer cases and accessories. We accept Bitcoin payments.">
-    <meta property="og:url" content="https://robotechy.com/">
-    <meta property="og:image" content="https://robotechy.com/images/RobotechySocialSharingImage.png">
-    <meta property="og:image:width" content="1200">
-    <meta property="og:image:height" content="630">
-    <meta property="og:image:alt" content="Robotechy — 3D printing Bitcoin store">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Robotechy | 3D Printing Bitcoin Store">
-    <meta name="twitter:description" content="3D printing store specializing in Bitcoin Seed Signer cases and accessories. We accept Bitcoin payments.">
-    <meta name="twitter:image" content="https://robotechy.com/images/RobotechySocialSharingImage.png">
-    <meta http-equiv="content-security-policy" content="default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'self' https:; font-src 'self'; base-uri 'self'; manifest-src 'self'; connect-src 'self' blob: https: wss:; img-src 'self' data: blob: https:; media-src 'self' https:">
-    <link rel="icon" type="image/png" href="/images/favicon-32x32.png">
-    <link rel="manifest" href="/manifest.webmanifest">
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Robotechy" />
+    <meta property="og:title" content="Robotechy | 3D Printing Bitcoin Store" />
+    <meta
+      property="og:description"
+      content="3D printing store specializing in Bitcoin Seed Signer cases and accessories. We accept Bitcoin payments."
+    />
+    <meta property="og:url" content="https://www.robotechy.com/" />
+    <meta
+      property="og:image"
+      content="https://www.robotechy.com/images/RobotechySocialSharingImage.png"
+    />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Robotechy — 3D printing Bitcoin store" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Robotechy | 3D Printing Bitcoin Store" />
+    <meta
+      name="twitter:description"
+      content="3D printing store specializing in Bitcoin Seed Signer cases and accessories. We accept Bitcoin payments."
+    />
+    <meta
+      name="twitter:image"
+      content="https://www.robotechy.com/images/RobotechySocialSharingImage.png"
+    />
+    <meta
+      http-equiv="content-security-policy"
+      content="default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'self' https:; font-src 'self'; base-uri 'self'; manifest-src 'self'; connect-src 'self' blob: https: wss:; img-src 'self' data: blob: https:; media-src 'self' https:"
+    />
+    <link rel="icon" type="image/png" href="/images/favicon-32x32.png" />
+    <link rel="manifest" href="/manifest.webmanifest" />
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/ShareProductButton.tsx
+++ b/src/components/ShareProductButton.tsx
@@ -26,7 +26,6 @@ import { useNostrPublish } from '@/hooks/useNostrPublish';
 import { useToast } from '@/hooks/useToast';
 import type { ProductData } from '@/lib/productUtils';
 import {
-  buildNjumpUrl,
   buildProductNaddr,
   buildShareNoteContent,
   buildShareNoteEvent,
@@ -93,21 +92,20 @@ export function ShareProductButton({
     [config.relayMetadata.relays]
   );
 
-  // The product's portable pointer plus its two human-facing links: the
-  // storefront page (primary — what copy/native share hand out) and the njump
-  // fallback. Memoised so every menu action uses the same URLs.
+  // The product's portable pointer and its storefront link (what copy / native
+  // share hand out). The default note also embeds the product photo so it
+  // renders inline when posted. Memoised so every menu action uses the same URL.
   const { naddr, storeUrl, defaultNote } = useMemo(() => {
     const naddr = buildProductNaddr(merchantPubkey, product.id, relayHints);
     const storeUrl = buildStoreUrl(naddr);
-    const njumpUrl = buildNjumpUrl(naddr);
     const defaultNote = buildShareNoteContent({
       title: product.title,
       priceLabel: formatPriceLabel(product.price),
       storeUrl,
-      njumpUrl,
+      imageUrl,
     });
     return { naddr, storeUrl, defaultNote };
-  }, [merchantPubkey, product.id, product.title, product.price, relayHints]);
+  }, [merchantPubkey, product.id, product.title, product.price, imageUrl, relayHints]);
 
   const copyLink = async () => {
     try {
@@ -232,8 +230,8 @@ export function ShareProductButton({
               Share to Nostr
             </DialogTitle>
             <DialogDescription>
-              Post a note about this product to your Nostr feed. The note links to the product on
-              the Robotechy store and njump so your followers can open it either way.
+              Post a note about this product to your Nostr feed. The note shows the product photo
+              and links to it on the Robotechy store.
             </DialogDescription>
           </DialogHeader>
 

--- a/src/lib/shareProduct.test.ts
+++ b/src/lib/shareProduct.test.ts
@@ -73,24 +73,34 @@ describe('formatPriceLabel', () => {
 });
 
 describe('buildShareNoteContent', () => {
-  it('composes the Robotechy share body with the store link then njump', () => {
+  it('composes the body with the product photo then the store link, no njump', () => {
     expect(
       buildShareNoteContent({
         title: 'Widget 3000',
         priceLabel: '21,000 sats',
         storeUrl: 'https://www.robotechy.com/naddr1abc',
-        njumpUrl: 'https://njump.me/naddr1abc',
+        imageUrl: 'https://img.example/widget.png',
       })
     ).toBe(
       'Check out Widget 3000 on Robotechy ⚡ 21,000 sats\n\n' +
-        'https://www.robotechy.com/naddr1abc\n' +
-        'https://njump.me/naddr1abc'
+        'https://img.example/widget.png\n\n' +
+        'https://www.robotechy.com/naddr1abc'
     );
+  });
+
+  it('drops the image line when there is no photo', () => {
+    expect(
+      buildShareNoteContent({
+        title: 'No Photo',
+        priceLabel: '1,000 sats',
+        storeUrl: 'https://www.robotechy.com/naddr1abc',
+      })
+    ).toBe('Check out No Photo on Robotechy ⚡ 1,000 sats\n\nhttps://www.robotechy.com/naddr1abc');
   });
 });
 
 describe('buildShareNoteEvent', () => {
-  it('builds a kind-1 note with a, both r links and image tags', () => {
+  it('puts the photo + store link in the body, njump as an r tag, image as imeta', () => {
     const event = buildShareNoteEvent({
       pubkey: PUBKEY,
       identifier: D,
@@ -105,23 +115,28 @@ describe('buildShareNoteEvent', () => {
     const storeUrl = buildStoreUrl(naddr);
     const njumpUrl = buildNjumpUrl(naddr);
     expect(event.content).toBe(
-      `Check out Widget 3000 on Robotechy ⚡ 21,000 sats\n\n${storeUrl}\n${njumpUrl}`
+      `Check out Widget 3000 on Robotechy ⚡ 21,000 sats\n\nhttps://img.example/widget.png\n\n${storeUrl}`
     );
+    // njump is referenced but never appears in the body (avoids Primal's
+    // "Mentioned event not found" for the kind-30402 listing).
+    expect(event.content).not.toContain('njump.me');
 
     expect(event.tags).toContainEqual(['a', `30402:${PUBKEY}:${D}`]);
     expect(event.tags).toContainEqual(['r', storeUrl]);
     expect(event.tags).toContainEqual(['r', njumpUrl]);
-    expect(event.tags).toContainEqual(['image', 'https://img.example/widget.png']);
+    expect(event.tags).toContainEqual(['imeta', 'url https://img.example/widget.png']);
+    // No non-standard bare `image` tag.
+    expect(event.tags.some(([name]) => name === 'image')).toBe(false);
   });
 
-  it('omits the image tag when there is no image', () => {
+  it('omits the imeta tag when there is no image', () => {
     const event = buildShareNoteEvent({
       pubkey: PUBKEY,
       identifier: D,
       title: 'No Photo',
       price: { amount: '1000', currency: 'sats' },
     });
-    expect(event.tags.some(([name]) => name === 'image')).toBe(false);
+    expect(event.tags.some(([name]) => name === 'imeta')).toBe(false);
   });
 
   it('honours an edited body but keeps the product tags', () => {

--- a/src/lib/shareProduct.test.ts
+++ b/src/lib/shareProduct.test.ts
@@ -150,4 +150,28 @@ describe('buildShareNoteEvent', () => {
     expect(event.content).toBe('My own words about this');
     expect(event.tags).toContainEqual(['a', `30402:${PUBKEY}:${D}`]);
   });
+
+  it('drops the imeta tag when an edited body no longer contains the image URL', () => {
+    const event = buildShareNoteEvent({
+      pubkey: PUBKEY,
+      identifier: D,
+      title: 'Widget 3000',
+      price: { amount: '21000', currency: 'sats' },
+      imageUrl: 'https://img.example/widget.png',
+      content: 'No photo link in my custom words',
+    });
+    expect(event.tags.some(([name]) => name === 'imeta')).toBe(false);
+  });
+
+  it('keeps the imeta tag when an edited body still contains the image URL', () => {
+    const event = buildShareNoteEvent({
+      pubkey: PUBKEY,
+      identifier: D,
+      title: 'Widget 3000',
+      price: { amount: '21000', currency: 'sats' },
+      imageUrl: 'https://img.example/widget.png',
+      content: 'Look: https://img.example/widget.png',
+    });
+    expect(event.tags).toContainEqual(['imeta', 'url https://img.example/widget.png']);
+  });
 });

--- a/src/lib/shareProduct.ts
+++ b/src/lib/shareProduct.ts
@@ -138,9 +138,10 @@ export function buildShareNoteEvent(input: ShareNoteEventInput): ShareNoteEventT
     ['r', storeUrl],
     ['r', njumpUrl],
   ];
-  if (input.imageUrl) {
-    // NIP-92: attach the image as media metadata (the URL is also in `content`,
-    // which is what actually renders inline across clients).
+  if (input.imageUrl && content.includes(input.imageUrl)) {
+    // NIP-92: attach the image as media metadata — but only when the URL is
+    // still in `content` (a user-edited body may have removed it), so the tag
+    // never describes an image the note doesn't actually show.
     tags.push(['imeta', `url ${input.imageUrl}`]);
   }
 

--- a/src/lib/shareProduct.ts
+++ b/src/lib/shareProduct.ts
@@ -72,22 +72,27 @@ export interface ShareNoteContentInput {
   title: string;
   priceLabel: string;
   storeUrl: string;
-  njumpUrl: string;
+  /** Product photo. Placed in the body so clients (Primal, Damus…) render it inline. */
+  imageUrl?: string;
 }
 
 /**
- * The human-readable body of the kind-1 note. Carries both links — the
- * storefront page first (the branded, buy-here destination) and the njump
- * fallback second, so it renders for Nostr-native and web readers alike:
- * `Check out Widget on Robotechy ⚡ 21,000 sats\n\n<storeUrl>\n<njumpUrl>`.
+ * The human-readable body of the kind-1 note. The product photo goes in the body
+ * (a bare image URL is what Nostr clients render inline), followed by the
+ * storefront link — the branded, buy-here destination. The njump link is left
+ * out of the body on purpose: clients like Primal try to inline-embed a njump
+ * `naddr` link as a mentioned event, and a NIP-99 (kind-30402) listing renders
+ * as "Mentioned event not found". njump is kept as an `r` tag instead (see
+ * `buildShareNoteEvent`).
  */
 export function buildShareNoteContent({
   title,
   priceLabel,
   storeUrl,
-  njumpUrl,
+  imageUrl,
 }: ShareNoteContentInput): string {
-  return `Check out ${title} on Robotechy ⚡ ${priceLabel}\n\n${storeUrl}\n${njumpUrl}`;
+  const intro = `Check out ${title} on Robotechy ⚡ ${priceLabel}`;
+  return [intro, imageUrl, storeUrl].filter(Boolean).join('\n\n');
 }
 
 export interface ShareNoteEventInput {
@@ -108,11 +113,12 @@ export interface ShareNoteEventTemplate {
 }
 
 /**
- * Build the kind-1 note template that references a product: the body links to
- * the product on both the storefront and njump, an `a` tag points at the
- * addressable product event, `r` tags carry the store and njump URLs, and (when
- * present) an `image` tag carries the product photo. This is a fresh note — it
- * never edits an existing event.
+ * Build the kind-1 note template that references a product: the body carries the
+ * product photo and the storefront link, an `a` tag points at the addressable
+ * product event, `r` tags carry the store and njump URLs (njump stays a tag so
+ * it doesn't trigger a failed inline-embed in the body), and — when present — a
+ * NIP-92 `imeta` tag describes the product photo. This is a fresh note; it never
+ * edits an existing event.
  */
 export function buildShareNoteEvent(input: ShareNoteEventInput): ShareNoteEventTemplate {
   const naddr = buildProductNaddr(input.pubkey, input.identifier, input.relays);
@@ -124,7 +130,7 @@ export function buildShareNoteEvent(input: ShareNoteEventInput): ShareNoteEventT
       title: input.title,
       priceLabel: formatPriceLabel(input.price),
       storeUrl,
-      njumpUrl,
+      imageUrl: input.imageUrl,
     });
 
   const tags: string[][] = [
@@ -133,7 +139,9 @@ export function buildShareNoteEvent(input: ShareNoteEventInput): ShareNoteEventT
     ['r', njumpUrl],
   ];
   if (input.imageUrl) {
-    tags.push(['image', input.imageUrl]);
+    // NIP-92: attach the image as media metadata (the URL is also in `content`,
+    // which is what actually renders inline across clients).
+    tags.push(['imeta', `url ${input.imageUrl}`]);
   }
 
   return { kind: 1, content, tags };


### PR DESCRIPTION
## Summary

Two independent fixes so a shared product actually shows an image (investigated on Primal, Lightning Piggy).

### 1. Nostr share note now carries the photo
Previously the note attached the product photo only as a non-standard `['image', url]` tag (clients don't render it), and the body linked to njump — which Primal tried to inline-embed as a mentioned **kind-30402** listing, showing *"Mentioned event not found"*.

Now the note body is: intro line → **product photo URL** (a bare image URL is what Primal/Damus/Amethyst render inline) → **storefront link**. njump is kept as an `r` tag but no longer appears in the body, so it stops triggering the failed embed. The photo is also attached as a NIP-92 `imeta` tag (replacing the bare `image` tag).

```
Check out Lightning Piggy on Robotechy ⚡ 21,000 sats

https://…/lightning-piggy.png

https://www.robotechy.com/naddr1…
```

### 2. `og:image` no longer 404s
`index.html`'s `og:image` / `twitter:image` / `og:url` used the apex `robotechy.com`, which **404s** for the social image; only `www.robotechy.com` serves it (verified 200). Pointed the static OG/Twitter tags at the working host, so link unfurls get a real preview image.

Fixes #81

## Test plan

1. CI: TypeScript, ESLint, Prettier, unit tests (`shareProduct` updated: photo+store in body, no njump in body, `imeta` tag, njump still an `r` tag), production build.
2. Share a product → **Share to Nostr**: the composed note shows the product photo inline and the storefront link; no "Mentioned event not found".
3. `curl -I https://www.robotechy.com/images/RobotechySocialSharingImage.png` → 200 (was 404 on the apex host used before).
4. Copy link / native Share still hand out the `www.robotechy.com/<naddr>` store URL (unchanged from #76).