### PR TITLE
fix: e2e + order-service fixes from v1.5.0 release verification

### DIFF
--- a/e2e/owner-add-product.mjs
+++ b/e2e/owner-add-product.mjs
@@ -44,7 +44,9 @@ await dialog.locator('#product-title').fill(TITLE);
 await dialog.locator('#product-summary').fill('Created by the owner-add-product e2e flow');
 await dialog.locator('#product-description').fill('A **test** product published over Nostr.');
 await dialog.locator('#product-price').fill('12345');
-await dialog.locator('#product-currency').fill('SATS');
+// Currency is a Select dropdown since #101 — pick SATS from the listbox.
+await dialog.locator('#product-currency').click();
+await page.getByRole('option', { name: 'SATS', exact: true }).click();
 await dialog.locator('[aria-label="Image URL 1"]').fill('https://robotechy.com/images/nostr-badge.png');
 await dialog.locator('#product-category').fill('e2e');
 await dialog.getByRole('button', { name: /^add$/i }).click();

--- a/e2e/owner-edit-product.mjs
+++ b/e2e/owner-edit-product.mjs
@@ -36,7 +36,9 @@ await page.waitForTimeout(2000);
 
 // Open a product detail page.
 if (PRODUCT) {
-  await page.getByText(PRODUCT, { exact: false }).first().click();
+  // The card's stretched overlay link (#98) sits above the title text, so
+  // click the card link itself rather than the h3 Playwright can't reach.
+  await page.getByRole('link', { name: PRODUCT }).first().click();
 } else {
   await page.locator('a[href^="/naddr"]').first().click();
 }

--- a/e2e/owner-remove-product.mjs
+++ b/e2e/owner-remove-product.mjs
@@ -33,7 +33,9 @@ await page.goto(BASE_URL + '/', { waitUntil: 'networkidle', timeout: 30000 });
 await page.waitForTimeout(2000);
 
 if (PRODUCT) {
-  await page.getByText(PRODUCT, { exact: false }).first().click();
+  // The card's stretched overlay link (#98) sits above the title text, so
+  // click the card link itself rather than the h3 Playwright can't reach.
+  await page.getByRole('link', { name: PRODUCT }).first().click();
 } else {
   await page.locator('a[href^="/naddr"]').first().click();
 }

--- a/e2e/owner-shipping.mjs
+++ b/e2e/owner-shipping.mjs
@@ -37,7 +37,9 @@ await page.waitForTimeout(800);
 const dialog = page.locator('[role="dialog"]').first();
 await dialog.locator('#shipping-title').fill(TITLE);
 await dialog.locator('#shipping-price').fill('500');
-await dialog.locator('#shipping-currency').fill('SATS');
+// Currency is a Select dropdown since #101 — pick SATS from the listbox.
+await dialog.locator('#shipping-currency').click();
+await page.getByRole('option', { name: 'SATS', exact: true }).click();
 await dialog.locator('#shipping-countries').fill('GB, IE');
 await dialog.locator('#shipping-carrier').fill('Royal Mail');
 

--- a/e2e/purchase-flow.mjs
+++ b/e2e/purchase-flow.mjs
@@ -65,7 +65,9 @@ await step('log in', async () => {
 });
 
 await step(`open "${PRODUCT}" and Buy It Now`, async () => {
-  await page.getByText(PRODUCT, { exact: false }).first().click();
+  // The card's stretched overlay link (#98) sits above the title text, so
+  // click the card link itself rather than the h3 Playwright can't reach.
+  await page.getByRole('link', { name: PRODUCT }).first().click();
   await page.waitForTimeout(2000);
   await page.getByRole('button', { name: /buy it now/i }).first().click();
   await page.waitForTimeout(1500);

--- a/order-service/lib/relayErrors.js
+++ b/order-service/lib/relayErrors.js
@@ -53,6 +53,12 @@ const RELAY_NOISE = [
   'eai_again',
   'rate-limit',
   'noting too much',
+  // Relay-side failure notice ("error: internal error") delivered on the
+  // subscription OK/CLOSED path (AbstractRelay.handleNext) — an internal
+  // nostr-tools promise nobody awaits. Crashed the service twice on
+  // 2026-07-17 while a relay was failing. Real order-processing errors are
+  // caught in the poll/publish try/catch paths, never via unhandledRejection.
+  'internal error',
 ];
 
 /**

--- a/order-service/lib/relayErrors.js
+++ b/order-service/lib/relayErrors.js
@@ -53,12 +53,13 @@ const RELAY_NOISE = [
   'eai_again',
   'rate-limit',
   'noting too much',
-  // Relay-side failure notice ("error: internal error") delivered on the
-  // subscription OK/CLOSED path (AbstractRelay.handleNext) — an internal
-  // nostr-tools promise nobody awaits. Crashed the service twice on
-  // 2026-07-17 while a relay was failing. Real order-processing errors are
-  // caught in the poll/publish try/catch paths, never via unhandledRejection.
-  'internal error',
+  // Relay-side failure notice delivered on the subscription OK/CLOSED path
+  // (AbstractRelay.handleNext) — an internal nostr-tools promise nobody
+  // awaits. Crashed the service twice on 2026-07-17 while a relay was
+  // failing. Matched WITH the relay machine-readable "error:" prefix so a
+  // Lightning/LNURL HTTP failure mentioning "internal error" (a real bug)
+  // can never be swallowed — same specificity principle as the entries above.
+  'error: internal error',
 ];
 
 /**

--- a/order-service/test/relayErrors.test.js
+++ b/order-service/test/relayErrors.test.js
@@ -27,6 +27,16 @@ test('ignores the relay publish timeout ("publish timed out") that crashed the s
   assert.equal(isIgnorableRelayError(new Error('fetch timeout')), false);
 });
 
+test('ignores the relay "error: internal error" notice that crashed the service (2026-07-17)', () => {
+  // A failing relay's OK/CLOSED reason, raised by nostr-tools on an internal
+  // promise nobody awaits — relay noise, must not kill order processing.
+  assert.equal(isIgnorableRelayError(new Error('error: internal error')), true);
+  // But an unprefixed "internal error" (e.g. an LNURL/Lightning HTTP failure)
+  // must STAY fatal — the needle is deliberately prefix-specific.
+  assert.equal(isIgnorableRelayError(new Error('Internal error')), false);
+  assert.equal(isIgnorableRelayError(new Error('LNURL: 500 internal error')), false);
+});
+
 test('ignores known transient relay/network errors (case-insensitive)', () => {
   for (const m of [
     'restricted: Pay on https://nostr.land for access.',


### PR DESCRIPTION
## Summary

Fixes found while running the full e2e suite ahead of the v1.5.0 release:

- **e2e scripts** updated for two intentional UI changes: currency fields are now Select dropdowns (#101), so scripts pick SATS from the listbox instead of `fill()`; product cards now have a stretched overlay link (#98), so scripts click the card link by role instead of the title text (Playwright's strict click can't reach the covered h3 — human clicks work fine).
- **order-service**: a relay returning `error: internal error` crashed the service twice during verification — one flaky relay could kill order processing. Added it to the `RELAY_NOISE` classification in `lib/relayErrors.js`, following the file's established pattern.

Fixes #104

## Test plan for QA

1. CI: all checks (order-service tests cover the classifier).
2. Full e2e suite against test store: 15/15 flows pass — search, all six owner flows, both purchase paths (manual + a **live NWC Lightning payment** on @getalby/sdk), share, story, reviews, comments, messaging, follow-us.
3. Order-service stays up through relay `internal error` notices (verified live during the NWC purchase).