### PR TITLE
docs: point CLAUDE.md at DEPLOYMENT.adoc for releases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,10 @@ npm run deploy        # Optional static-only Nostr/Blossom mirror - NOT the prod
 `package.json`'s version on main FIRST (the footer reads it), then push a `v<version>`
 tag — the tag push itself triggers the production deploy (GitHub workflow →
 black-panther's self-hosted runner rebuilds the `robotechy` container, which serves
-both the site and the order-service). `npm run deploy` only updates the static mirror.
+both the site and the order-service). NOTE the tag only *triggers* the deploy — the
+container always builds from the **latest `main`** (the Docker build context is the
+repo's default branch), so the tag does not pin what ships, and rolling back means
+reverting on main first. `npm run deploy` only updates the static mirror.
 
 For running a single test file:
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,14 @@ npm run lint          # Run ESLint
 npm run lint:fix      # Run ESLint with auto-fix
 npm run format        # Format code with Prettier
 npm run format:check  # Check code formatting
-npm run deploy        # Build and deploy via nostr-deploy-cli
+npm run deploy        # Optional static-only Nostr/Blossom mirror - NOT the production deploy
 ```
+
+**Releasing / deploying to production**: see `docs/DEPLOYMENT.adoc`. In short: bump
+`package.json`'s version on main FIRST (the footer reads it), then push a `v<version>`
+tag — the tag push itself triggers the production deploy (GitHub workflow →
+black-panther's self-hosted runner rebuilds the `robotechy` container, which serves
+both the site and the order-service). `npm run deploy` only updates the static mirror.
 
 For running a single test file:
 ```bash


### PR DESCRIPTION
## Summary

CLAUDE.md described `npm run deploy` as "Build and deploy via nostr-deploy-cli", which reads as the production deploy — it's actually only the optional static Nostr/Blossom mirror (per `docs/DEPLOYMENT.adoc`). The real production deploy is the **tag push** (workflow → black-panther runner → container rebuild serving site + order-service).

During the v1.5.0 release this mislabel sent the deploy down the mirror path; the tag had already deployed production (before the version bump merged), which is why the footer briefly showed v1.1.1.

CLAUDE.md now labels `npm run deploy` correctly and adds a short Releasing pointer: bump version first → tag → the tag deploys.

## Test plan for QA

Docs-only; CI checks pass.